### PR TITLE
Add remaining Board API endpoints

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -122,6 +122,7 @@ Most of the API is available:
     client.board.accept_takeback
     client.board.decline_takeback
     client.board.claim_victory
+    client.board.go_berserk
 
     client.bots.stream_incoming_events
     client.bots.stream_game_state

--- a/README.rst
+++ b/README.rst
@@ -111,6 +111,7 @@ Most of the API is available:
     client.board.stream_game_state
     client.board.make_move
     client.board.post_message
+    client.board.get_game_chat
     client.board.abort_game
     client.board.resign_game
     client.board.handle_draw_offer

--- a/README.rst
+++ b/README.rst
@@ -121,6 +121,7 @@ Most of the API is available:
     client.board.offer_takeback
     client.board.accept_takeback
     client.board.decline_takeback
+    client.board.claim_victory
 
     client.bots.stream_incoming_events
     client.bots.stream_game_state

--- a/berserk/clients.py
+++ b/berserk/clients.py
@@ -1095,6 +1095,16 @@ class Board(BaseClient):
         path = f'/api/board/game/{game_id}/claim-victory/'
         return self._r.post(path)['ok']
 
+    def go_berserk(self, game_id):
+        """Go berserk on an arena tournament game.
+
+        :param str game_id: ID of an in-progress game
+        :return: True if successful
+        :rtype: bool
+        """
+        path = f'/api/board/game/{game_id}/berserk'
+        return self._r.post(path)['ok']
+
 
 class Bots(BaseClient):
     """Client for bot-related endpoints."""

--- a/berserk/clients.py
+++ b/berserk/clients.py
@@ -967,6 +967,15 @@ class Board(BaseClient):
         payload = {"room": room, "text": text}
         return self._r.post(path, json=payload)["ok"]
 
+    def get_game_chat(self, game_id: str) -> List[Dict[str, str]]:
+        """Get the messages posted in the game chat.
+
+        :param str game_id: ID of a game
+        :return: list of game chat events
+        """
+        path = f"api/board/game/{game_id}/chat"
+        return self._r.get(path)
+
     def abort_game(self, game_id):
         """Abort a board game.
 
@@ -1081,7 +1090,7 @@ class Board(BaseClient):
         """
         return self.handle_takeback_offer(game_id, False)
 
-    def claim_victory(self, game_id):
+    def claim_victory(self, game_id: str) -> bool:
         """Claim victory when the opponent has left the game for a while.
 
         Generally, this should only be called once the `opponentGone` event
@@ -1090,20 +1099,18 @@ class Board(BaseClient):
 
         :param str game_id: ID of an in-progress game
         :return: True if successful
-        :rtype: bool
         """
-        path = f'/api/board/game/{game_id}/claim-victory/'
-        return self._r.post(path)['ok']
+        path = f"/api/board/game/{game_id}/claim-victory/"
+        return self._r.post(path)["ok"]
 
-    def go_berserk(self, game_id):
+    def go_berserk(self, game_id: str) -> bool:
         """Go berserk on an arena tournament game.
 
         :param str game_id: ID of an in-progress game
         :return: True if successful
-        :rtype: bool
         """
-        path = f'/api/board/game/{game_id}/berserk'
-        return self._r.post(path)['ok']
+        path = f"/api/board/game/{game_id}/berserk"
+        return self._r.post(path)["ok"]
 
 
 class Bots(BaseClient):

--- a/berserk/clients.py
+++ b/berserk/clients.py
@@ -1081,6 +1081,20 @@ class Board(BaseClient):
         """
         return self.handle_takeback_offer(game_id, False)
 
+    def claim_victory(self, game_id):
+        """Claim victory when the opponent has left the game for a while.
+
+        Generally, this should only be called once the `opponentGone` event
+        is received in the board game state stream and the `claimWinInSeconds`
+        time has elapsed.
+
+        :param str game_id: ID of an in-progress game
+        :return: True if successful
+        :rtype: bool
+        """
+        path = f'/api/board/game/{game_id}/claim-victory/'
+        return self._r.post(path)['ok']
+
 
 class Bots(BaseClient):
     """Client for bot-related endpoints."""


### PR DESCRIPTION
Adds the remaining Board API endpoints:

- `/api/board/game/{game_id}/chat`
- `/api/board/game/{game_id}/claim-victory`
- `/api/board/game/{game_id}/berserk`