### PR TITLE
Use GPLv3+ trove classifier

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ berserk
     :alt: Test status
 
 .. image:: https://badge.fury.io/py/berserk.svg
-    :target: https://pypi.python.org/pypi/berserk
+    :target: https://pypi.org/project/berserk/
     :alt: PyPI package
 
 .. image:: https://github.com/lichess-org/berserk/actions/workflows/docs.yml/badge.svg

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ keywords = ["lichess", "chess", "api", "client"]
 classifiers = [
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
+        'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.8',


### PR DESCRIPTION
This should "fix" the double license entries in the pypi page