### PR TITLE
Update endpoint paths

### DIFF
--- a/berserk/clients.py
+++ b/berserk/clients.py
@@ -563,7 +563,7 @@ class Games(FmtClient):
         :param opening: whether to include the opening name
         :return: iterator over the exported games, as JSON or PGN
         """
-        path = "games/export/_ids"
+        path = "api/games/export/_ids"
         params = {
             "moves": moves,
             "tags": tags,

--- a/berserk/clients.py
+++ b/berserk/clients.py
@@ -1606,7 +1606,7 @@ class Studies(BaseClient):
 
         :return: chapter PGN
         """
-        path = f"/study/{study_id}/{chapter_id}.pgn"
+        path = f"api/study/{study_id}/{chapter_id}.pgn"
         return self._r.get(path, fmt=PGN)
 
     def export(self, study_id: str) -> Iterator[str]:
@@ -1614,7 +1614,7 @@ class Studies(BaseClient):
 
         :return: iterator over all chapters as PGN
         """
-        path = f"/study/{study_id}.pgn"
+        path = f"api/study/{study_id}.pgn"
         return self._r.get(path, fmt=PGN, stream=True)
 
 


### PR DESCRIPTION
Updates `Games.export_multi`, `Studies.export_chapter`, and `Studies.export` to prepend `api/` to their paths. Interestingly enough, they worked as it was before but utilizing the path documented in the API will allow for the `check-endpoints` script to pick them up as implemented.

Related to #6 