### PR TITLE
Fix parsing time strings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+* Fixed response handling of several endpoints related to datetime parsing
+
 v0.12.1 (2023-05-13)
 --------------------
 

--- a/berserk/utils.py
+++ b/berserk/utils.py
@@ -30,10 +30,10 @@ def datetime_from_millis(millis: float) -> datetime:
 def datetime_from_str(dt_str: str) -> datetime:
     """Convert the time in a string to a datetime.
 
-    UTC is assumed. The returned datetime is timezone aware. The format must match
-    ``%Y-%m-%dT%H:%M:%S.%fZ``.
+    UTC is assumed. The returned datetime is timezone aware.
+    The format must match ISO 8601.
     """
-    dt = datetime.strptime(dt_str, "%Y-%m-%dT%H:%M:%S.%fZ")
+    dt = datetime.fromisoformat(dt_str)
     return dt.replace(tzinfo=timezone.utc)
 
 
@@ -41,7 +41,7 @@ def datetime_from_str_or_millis(millis_or_str: str | int) -> datetime:
     """Convert a string or int to a datetime.
 
     UTC is assumed. The returned datetime is timezone aware. If the input is a string,
-    the format must match ``%Y-%m-%dT%H:%M:%S.%fZ``.
+    the format must match ISO 8601.
     """
     if isinstance(millis_or_str, int):
         return datetime_from_millis(millis_or_str)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,10 +5,6 @@ import pytest
 
 from berserk import utils
 
-
-TIME_FMT = "%Y-%m-%dT%H:%M:%S.%fZ"
-
-
 Case = collections.namedtuple("Case", "dt seconds millis text")
 
 
@@ -16,7 +12,7 @@ Case = collections.namedtuple("Case", "dt seconds millis text")
 def time_case():
     dt = datetime.datetime(2017, 12, 28, 23, 52, 30, tzinfo=datetime.timezone.utc)
     ts = dt.timestamp()
-    return Case(dt, ts, ts * 1000, dt.strftime(TIME_FMT))
+    return Case(dt, ts, ts * 1000, dt.isoformat())
 
 
 def test_to_millis(time_case):


### PR DESCRIPTION
Currently endpoints whose responses are converted with `models.Tournament.convert` are broken where the server returns date strings instead of milliseconds. The `TIME_FMT` mentioned here is not the one that is being returned by Lichess but rather standard ISO 8601 strings.

I found `tournaments.get_tournament`, `tournaments.create_arena`, & `tournaments.create_swiss` to be broken following a discord report. They seem to work with the changes here. I don't know why some of `client.challenges` functions need `models.Tournament.convert` but they still work following this change too.