### PR TITLE
check-endpoints.py: Updating regex to treat search items as distinct path.

### DIFF
--- a/check-endpoints.py
+++ b/check-endpoints.py
@@ -33,7 +33,7 @@ for endpoint, data in spec["paths"].items():
     endpoint_without_slash = endpoint[1:]
 
     # Replace parameter placeholders with regular expression
-    endpoint_regex = re.sub(r"{[^/]+?}", r"[^/]+?", endpoint_without_slash)
+    endpoint_regex = re.sub(r"{[^/]+?}", r"[^/]+?", endpoint_without_slash) + '"'
 
     # Check if endpoint or a variation of it is present in file
     if not re.search(endpoint_regex, clients_content):


### PR DESCRIPTION
Fixes #10 

Issue was a result of how the regex search is being performed. It searches for each item without the leading '/', and it doesn't search in the context of the item being used as an exact path.

So "/oauth" becomes "oauth" - which exists as a string on its own elsewhere in clients.py. "/api/token" becomes "api/token", which has a child ("api/token/test") in clients.py, which is being counted as a match because the string "api/token" can be found in the string "api/token/test").

I fixed this (kinda hacky) by adding a " (double quote) to the end of the string the regex searches for, so the examples above will now search for oauth**"** and api/token/test**"** - which do not exist on their own as distinct **path = "<insert path>** items.

A better fix would be to search for the string in leading _and_ trailing double-quotes, or even force compliance that all paths have to take the format **path = "<insert path>"** - however, some paths in clients.py have been entered with a leading "/" (path = "/api/rel/following" is an example), and 1) adding logic to account for this would add more complexity, and 2) I'd rather not edit clients.py to force that compliance because I'm concerned about breaking something.