### PR TITLE
Add a missing function in the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,6 +98,7 @@ Most of the API is available:
     client.games.get_ongoing
     client.games.stream_game_moves
     client.games.get_tv_channels
+    client.games.import_game
 
     client.challenges.create
     client.challenges.create_ai


### PR DESCRIPTION
**Context**:
The function is implemented in [this file](https://github.com/lichess-org/berserk/blob/b5f94f74a94372be9910430bf3bcf5e5798dc290/berserk/clients.py#L659), while it's missing in the README.

**Change**:
Add the missing function in the README file.

**Tested**:
N/A