### PR TITLE
Adding methods to access /api/broadcast functionality

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -148,6 +148,7 @@ Most of the API is available:
     client.tournaments.stream_results
     client.tournaments.stream_by_creator
 
+    client.broadcasts.get_official
     client.broadcasts.create
     client.broadcasts.get
     client.broadcasts.update
@@ -155,6 +156,8 @@ Most of the API is available:
     client.broadcasts.create_round
     client.broadcasts.get_round
     client.broadcasts.update_round
+    client.broadcasts.get_round_pgns
+    client.broadcasts.get_pgns
 
     client.simuls.get
 

--- a/berserk/clients.py
+++ b/berserk/clients.py
@@ -1496,6 +1496,26 @@ class Broadcasts(BaseClient):
         path = f"/broadcast/{slug}/{broadcast_id}"
         return self._r.get(path, converter=models.Broadcast.convert)
 
+    def get_multi(self, num_to_return: int | None = None) -> Iterator[Dict[str, Any]]:
+        """Get the list of incoming, ongoing, and finished official broadcasts.
+        Sorted by start date, most recent first.
+        
+        :param num_to_return: maximum number of braodasts to fetch, all by default
+        :return: data for up to num_to_return broadcasts
+        """
+        path = "/api/broadcast"
+        params = {"nb": num_to_return}
+        return self._r.get(path, params=params, stream=True)
+        
+    def get_tournament_pgn(self, broadcast_tournament_id: str) -> Iterator[Dict[str, Any]]:
+        """Get all games of all rounds of a broadcast in PGN format.
+        
+        :param broadcast_tournament_id: the broadcast tournament ID
+        :return: all games in the broadcast tournament in PGN format
+        """
+        path = f"/api/broadcast/{broadcast_tournament_id}.pgn"
+        return self._r.get(path, fmt=PGN, stream=True)
+
     def update(
         self,
         broadcast_id: str,
@@ -1565,6 +1585,15 @@ class Broadcasts(BaseClient):
         """
         path = f"/broadcast/-/-/{broadcast_id}"
         return self._r.get(path, converter=models.Broadcast.convert)
+        
+    def get_round_pgn(self, broadcast_round_id: str) -> Iterator[Dict[str, Any]]:
+        """Get all games of a single round of a broadcast in pgn format
+        
+        :param broadcast_round_id: broadcast round ID
+        :return: all games of the broadcast round in pgn format
+        """
+        path = f"/api/broadcast/round/{broadcast_round_id}.pgn"
+        return self._r.get(path, fmt=PGN, stream=True)
 
     def update_round(
         self,
@@ -1584,7 +1613,7 @@ class Broadcasts(BaseClient):
         path = f"/broadcast/round/{broadcast_id}/edit"
         payload = {"name": name, "syncUrl": syncUrl, "startsAt": startsAt}
         return self._r.post(path, json=payload, converter=models.Broadcast.convert)
-
+    
 
 class Simuls(BaseClient):
     """Simultaneous exhibitions - one vs many."""

--- a/berserk/clients.py
+++ b/berserk/clients.py
@@ -1462,6 +1462,17 @@ class Tournaments(FmtClient):
 class Broadcasts(BaseClient):
     """Broadcast of one or more games."""
 
+    def get_official(self, nb: int | None = None) -> Iterator[Dict[str, Any]]:
+        """Get the list of incoming, ongoing, and finished official broadcasts.
+        Sorted by start date, most recent first.
+
+        :param nb: maximum number of broadcasts to fetch, default is 20
+        :return: iterator over broadcast objects
+        """
+        path = "/api/broadcast"
+        params = {"nb": nb}
+        return self._r.get(path, params=params, stream=True)
+
     def create(
         self,
         name: str,
@@ -1495,28 +1506,6 @@ class Broadcasts(BaseClient):
         """
         path = f"/broadcast/{slug}/{broadcast_id}"
         return self._r.get(path, converter=models.Broadcast.convert)
-
-    def get_multi(self, num_to_return: int | None = None) -> Iterator[Dict[str, Any]]:
-        """Get the list of incoming, ongoing, and finished official broadcasts.
-        Sorted by start date, most recent first.
-
-        :param num_to_return: maximum number of braodasts to fetch, all by default
-        :return: data for up to num_to_return broadcasts
-        """
-        path = "/api/broadcast"
-        params = {"nb": num_to_return}
-        return self._r.get(path, params=params, stream=True)
-
-    def get_tournament_pgn(
-        self, broadcast_tournament_id: str
-    ) -> Iterator[Dict[str, Any]]:
-        """Get all games of all rounds of a broadcast in PGN format.
-
-        :param broadcast_tournament_id: the broadcast tournament ID
-        :return: all games in the broadcast tournament in PGN format
-        """
-        path = f"/api/broadcast/{broadcast_tournament_id}.pgn"
-        return self._r.get(path, stream=True)
 
     def update(
         self,
@@ -1588,15 +1577,6 @@ class Broadcasts(BaseClient):
         path = f"/broadcast/-/-/{broadcast_id}"
         return self._r.get(path, converter=models.Broadcast.convert)
 
-    def get_round_pgn(self, broadcast_round_id: str) -> Iterator[Dict[str, Any]]:
-        """Get all games of a single round of a broadcast in pgn format
-
-        :param broadcast_round_id: broadcast round ID
-        :return: all games of the broadcast round in pgn format
-        """
-        path = f"/api/broadcast/round/{broadcast_round_id}.pgn"
-        return self._r.get(path, stream=True)
-
     def update_round(
         self,
         broadcast_id: str,
@@ -1615,6 +1595,24 @@ class Broadcasts(BaseClient):
         path = f"/broadcast/round/{broadcast_id}/edit"
         payload = {"name": name, "syncUrl": syncUrl, "startsAt": startsAt}
         return self._r.post(path, json=payload, converter=models.Broadcast.convert)
+
+    def get_round_pgns(self, broadcast_round_id: str) -> Iterator[str]:
+        """Get all games of a single round of a broadcast in pgn format
+
+        :param broadcast_round_id: broadcast round ID
+        :return: iterator over all games of the broadcast round in PGN format
+        """
+        path = f"/api/broadcast/round/{broadcast_round_id}.pgn"
+        return self._r.get(path, fmt=PGN, stream=True)
+
+    def get_pgns(self, broadcast_id: str) -> Iterator[str]:
+        """Get all games of all rounds of a broadcast in PGN format.
+
+        :param broadcast_id: the broadcast ID
+        :return: iterator over all games of the broadcast in PGN format
+        """
+        path = f"/api/broadcast/{broadcast_id}.pgn"
+        return self._r.get(path, fmt=PGN, stream=True)
 
 
 class Simuls(BaseClient):

--- a/berserk/clients.py
+++ b/berserk/clients.py
@@ -1499,22 +1499,24 @@ class Broadcasts(BaseClient):
     def get_multi(self, num_to_return: int | None = None) -> Iterator[Dict[str, Any]]:
         """Get the list of incoming, ongoing, and finished official broadcasts.
         Sorted by start date, most recent first.
-        
+
         :param num_to_return: maximum number of braodasts to fetch, all by default
         :return: data for up to num_to_return broadcasts
         """
         path = "/api/broadcast"
         params = {"nb": num_to_return}
         return self._r.get(path, params=params, stream=True)
-        
-    def get_tournament_pgn(self, broadcast_tournament_id: str) -> Iterator[Dict[str, Any]]:
+
+    def get_tournament_pgn(
+        self, broadcast_tournament_id: str
+    ) -> Iterator[Dict[str, Any]]:
         """Get all games of all rounds of a broadcast in PGN format.
-        
+
         :param broadcast_tournament_id: the broadcast tournament ID
         :return: all games in the broadcast tournament in PGN format
         """
         path = f"/api/broadcast/{broadcast_tournament_id}.pgn"
-        return self._r.get(path, fmt=PGN, stream=True)
+        return self._r.get(path, stream=True)
 
     def update(
         self,
@@ -1585,15 +1587,15 @@ class Broadcasts(BaseClient):
         """
         path = f"/broadcast/-/-/{broadcast_id}"
         return self._r.get(path, converter=models.Broadcast.convert)
-        
+
     def get_round_pgn(self, broadcast_round_id: str) -> Iterator[Dict[str, Any]]:
         """Get all games of a single round of a broadcast in pgn format
-        
+
         :param broadcast_round_id: broadcast round ID
         :return: all games of the broadcast round in pgn format
         """
         path = f"/api/broadcast/round/{broadcast_round_id}.pgn"
-        return self._r.get(path, fmt=PGN, stream=True)
+        return self._r.get(path, stream=True)
 
     def update_round(
         self,
@@ -1613,7 +1615,7 @@ class Broadcasts(BaseClient):
         path = f"/broadcast/round/{broadcast_id}/edit"
         payload = {"name": name, "syncUrl": syncUrl, "startsAt": startsAt}
         return self._r.post(path, json=payload, converter=models.Broadcast.convert)
-    
+
 
 class Simuls(BaseClient):
     """Simultaneous exhibitions - one vs many."""


### PR DESCRIPTION
Adding methods for /api/broadcast functionality (addressing #6  ):

get_multi --> /api/broadcast
get_tournament_pgn --> /api/broadcast/{broadcastTournamentID}.pgn
get_round_gpn --> /api/broadcast/round/{broadcastRoundID}.pgn