### PR TITLE
Implemented 3 API endpoints for Teams

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -153,6 +153,8 @@ Most of the API is available:
     client.teams.join
     client.teams.leave
     client.teams.kick_member
+    client.teams.get_join_requests
+    client.teams.accept_join_request
 
     client.tournaments.get
     client.tournaments.get_tournament

--- a/berserk/clients/teams.py
+++ b/berserk/clients/teams.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Iterator, Any, Dict
 
 from .. import models
-from ..formats import NDJSON
+from ..formats import NDJSON, JSON_LIST
 from .base import BaseClient
 
 
@@ -49,4 +49,26 @@ class Teams(BaseClient):
         :param user_id: ID of a team member
         """
         path = f"/team/{team_id}/kick/{user_id}"
+        self._r.post(path)
+
+    def get_join_requests(
+        self, team_id: str, declined: bool = False
+    ) -> list[Dict[str, Any]]:
+        """Get pending join requests of your team
+
+        :param team_id: ID of a team
+        :param declined: Get the declined join requests
+        :return: List of join requests
+        """
+        path = f"/api/team/{team_id}/requests"
+        params = {"declined": declined}
+        return self._r.get(path, params=params, fmt=JSON_LIST)
+
+    def accept_join_request(self, team_id: str, user_id: str) -> None:
+        """Accept someone's request to join the team
+
+        :param team_id: ID of a team
+        :param user_id: ID of a member requesting to join
+        """
+        path = f"/api/team/{team_id}/request/{user_id}/accept"
         self._r.post(path)

--- a/berserk/clients/teams.py
+++ b/berserk/clients/teams.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Iterator, Any, Dict
+from typing import Iterator, Any, Dict, List
 
 from .. import models
 from ..formats import NDJSON, JSON_LIST
@@ -11,6 +11,7 @@ class Teams(BaseClient):
     def get_members(self, team_id: str) -> Iterator[Dict[str, Any]]:
         """Get members of a team.
 
+        :param team_id: ID of the team to get members from
         :return: users on the given team
         """
         path = f"/api/team/{team_id}/users"
@@ -23,9 +24,9 @@ class Teams(BaseClient):
     ) -> None:
         """Join a team.
 
-        :param team_id: ID of a team
-        :param message: Optional request message, if the team requires one
-        :param password: Optional password, if the team requires one.
+        :param team_id: ID of the team to join
+        :param message: optional request message, if the team requires one
+        :param password: optional password, if the team requires one
         """
         path = f"/team/{team_id}/join"
         payload = {
@@ -37,7 +38,7 @@ class Teams(BaseClient):
     def leave(self, team_id: str) -> None:
         """Leave a team.
 
-        :param team_id: ID of a team
+        :param team_id: ID of the team to leave
         """
         path = f"/team/{team_id}/quit"
         self._r.post(path)
@@ -45,30 +46,30 @@ class Teams(BaseClient):
     def kick_member(self, team_id: str, user_id: str) -> None:
         """Kick a member out of your team.
 
-        :param team_id: ID of a team
-        :param user_id: ID of a team member
+        :param team_id: ID of the team to kick from
+        :param user_id: ID of the user to kick from the team
         """
         path = f"/team/{team_id}/kick/{user_id}"
         self._r.post(path)
 
     def get_join_requests(
         self, team_id: str, declined: bool = False
-    ) -> list[Dict[str, Any]]:
+    ) -> List[Dict[str, Any]]:
         """Get pending join requests of your team
 
-        :param team_id: ID of a team
-        :param declined: Get the declined join requests
-        :return: List of join requests
+        :param team_id: ID of the team to request the join requests from
+        :param declined: whether to show declined requests instead of pending ones
+        :return: list of join requests
         """
         path = f"/api/team/{team_id}/requests"
         params = {"declined": declined}
         return self._r.get(path, params=params, fmt=JSON_LIST)
 
     def accept_join_request(self, team_id: str, user_id: str) -> None:
-        """Accept someone's request to join the team
+        """Accept someone's request to join one of your teams
 
-        :param team_id: ID of a team
-        :param user_id: ID of a member requesting to join
+        :param team_id: ID of the team to accept the request for
+        :param user_id: ID of the user requesting to join
         """
         path = f"/api/team/{team_id}/request/{user_id}/accept"
         self._r.post(path)


### PR DESCRIPTION
Thank you for the project. This is my first time contributing.

Implemented the following endpoints:
	1. get_join_request
	2. accept_join_request
	3. get_swiss_tournament
	
I had a couple of questions. 

1. The already existing `kick_member` function doesn't return anything. However, the [API](https://lichess.org/api#tag/Teams/operation/teamIdKickUserId) suggests that it returns a dictionary, confirming if the member has been kicked or not. I have returned a dictionary in `accept_join_request`, and would like to know if I should keep it and change the `kick_member` function or change the `accept_join_request`. 
2. In `get_join_request`, I am returning a iterator, I am unsure about the formatting type, so I left it as default. I have tested it, and it did work as intended but wanted to confirm if there is a specific format that should be used.