### PR TITLE
Implement `/api/external_engine` endpoints

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,14 +4,20 @@ Changelog
 To be released
 --------------
 
-* Add ``
+* Add::
+    client.external_engine.get
+    client.external_engine.get_by_id
+    client.external_engine.create
+    client.external_engine.update
+    client.external_engine.delete
+* Add::
     client.tournaments.edit_swiss
     client.tournaments.get_swiss
     client.tournaments.join_swiss
     client.tournaments.stream_swiss_results
     client.tournaments.schedule_swiss_next_round
     client.tournaments.terminate_swiss
-    client.tournaments.withdraw_swiss``
+    client.tournaments.withdraw_swiss
 * Add ``client.puzzles.create_race``
 * Add ``client.users.get_by_autocomplete``
 

--- a/README.rst
+++ b/README.rst
@@ -124,6 +124,12 @@ Most of the API is available:
     client.explorer.get_player_games
     client.explorer.stream_player_games
 
+    client.external_engine.get
+    client.external_engine.get_by_id
+    client.external_engine.create
+    client.external_engine.update
+    client.external_engine.delete
+
     client.games.export
     client.games.export_ongoing_by_player
     client.games.export_by_player

--- a/berserk/clients/__init__.py
+++ b/berserk/clients/__init__.py
@@ -22,6 +22,7 @@ from .tv import TV
 from .tablebase import Tablebase
 from .opening_explorer import OpeningExplorer
 from .bulk_pairings import BulkPairings
+from .external_engine import ExternalEngine
 
 __all__ = [
     "Client",
@@ -43,6 +44,7 @@ __all__ = [
     "TV",
     "Tablebase",
     "BulkPairings",
+    "ExternalEngine",
 ]
 
 
@@ -67,6 +69,7 @@ class Client(BaseClient):
     - :class:`tv <berserk.clients.TV>` - get information on tv channels and games
     - :class:`tablebase <berserk.clients.Tablebase>` - lookup endgame tablebase
     - :class:`bulk_pairings <berserk.clients.BulkPairing>` - manage bulk pairings
+    - :class: `external_engine <berserk.clients.ExternalEngine>` - manage external engines
 
     :param session: request session, authenticated as needed
     :param base_url: base API URL to use (if other than the default)
@@ -106,3 +109,4 @@ class Client(BaseClient):
         self.tablebase = Tablebase(session, tablebase_url)
         self.opening_explorer = OpeningExplorer(session, explorer_url)
         self.bulk_pairings = BulkPairings(session, base_url)
+        self.external_engine = ExternalEngine(session, base_url)

--- a/berserk/clients/external_engine.py
+++ b/berserk/clients/external_engine.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List
+from typing import List, cast
 
 from .base import BaseClient
 
@@ -16,7 +16,7 @@ class ExternalEngine(BaseClient):
         :return: info about the external engines
         """
         path = "/api/external-engine"
-        return self._r.get(path)
+        return cast(List[ExternalEngine], self._r.get(path))
 
     def get_by_id(self, engine_id: str) -> ExternalEngine:
         """Get properties and credentials of an external engine.
@@ -27,7 +27,7 @@ class ExternalEngine(BaseClient):
         :return: info about the external engine
         """
         path = f"/api/external-engine/{engine_id}"
-        return self._r.get(path)
+        return cast(ExternalEngine, self._r.get(path))
 
     def create(
         self,
@@ -62,7 +62,7 @@ class ExternalEngine(BaseClient):
             "providerSecret": provider_secret,
             "providerData": provider_data,
         }
-        return self._r.post(path=path, payload=payload)
+        return cast(ExternalEngine, self._r.post(path=path, payload=payload))
 
     def update(
         self,
@@ -99,7 +99,7 @@ class ExternalEngine(BaseClient):
             "providerSecret": provider_secret,
             "providerData": provider_data,
         }
-        return self._r.request(method="PUT", path=path, payload=payload)
+        return cast(ExternalEngine, self._r.request(method="PUT", path=path, payload=payload))
 
     def delete(self, engine_id: str) -> None:
         """Unregisters an external engine.

--- a/berserk/clients/external_engine.py
+++ b/berserk/clients/external_engine.py
@@ -99,7 +99,9 @@ class ExternalEngine(BaseClient):
             "providerSecret": provider_secret,
             "providerData": provider_data,
         }
-        return cast(ExternalEngine, self._r.request(method="PUT", path=path, payload=payload))
+        return cast(
+            ExternalEngine, self._r.request(method="PUT", path=path, payload=payload)
+        )
 
     def delete(self, engine_id: str) -> None:
         """Unregisters an external engine.

--- a/berserk/clients/external_engine.py
+++ b/berserk/clients/external_engine.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from .base import BaseClient
+
+
+class ExternalEngine(BaseClient):
+    def get(self) -> Dict[str, Any]:
+        """Lists all external engines that have been registered for the user, and the credentials required to use them.
+
+        :return: info about the external engines
+        """
+        path = "/api/external-engine"
+        return self._r.get(path)
+
+    def get_by_id(self, engine_id: str) -> Dict[str, Any]:
+        """Get properties and credentials of an external engine.
+
+        :param engine_id: external engine ID
+        :return: info about the external engine
+        """
+        path = f"/api/external-engine/{engine_id}"
+        return self._r.get(path)
+
+    def create(
+        self,
+        name: str,
+        max_threads: int,
+        max_hash_table_size: int,
+        default_depth: int,
+        provider_secret: str,
+        variants: List[str] | None = None,
+        provider_data: str | None = None,
+    ) -> Dict[str, Any]:
+        """Registers a new external engine for the user.
+
+        :param name: engine display name
+        :param max_threads: maximum number of available threads
+        :param max_hash_table_size: maximum available hash table size, in MiB
+        :param default_depth: estimated depth of normal search
+        :param provider_secret: random token that used to wait for analysis requests and provide analysis
+        :param variants: list of supported chess variants
+        :param provider_data: arbitrary data that engine provider can use for identification or bookkeeping
+        :return: info about the external engine
+        """
+        path = "/api/external-engine"
+        payload = {
+            "name": name,
+            "maxThreads": max_threads,
+            "maxHash": max_hash_table_size,
+            "defaultDepth": default_depth,
+            "variants": variants,
+            "providerSecret": provider_secret,
+            "providerData": provider_data,
+        }
+        return self._r.post(path=path, payload=payload)
+
+    def update(
+        self,
+        engine_id: str,
+        name: str,
+        max_threads: int,
+        max_hash_table_size: int,
+        default_depth: int,
+        provider_secret: str,
+        variants: List[str] | None = None,
+        provider_data: str | None = None,
+    ) -> Dict[str, Any]:
+        """Updates the properties of an external engine.
+
+        :param engine_id: engine ID
+        :param name: engine display name
+        :param max_threads: maximum number of available threads
+        :param max_hash_table_size: maximum available hash table size, in MiB
+        :param default_depth: estimated depth of normal search
+        :param provider_secret: random token that used to wait for analysis requests and provide analysis
+        :param variants: list of supported chess variants
+        :param provider_data: arbitrary data that engine provider can use for identification or bookkeeping
+        :return: info about the external engine
+        """
+        path = f"/api/external-engine/{engine_id}"
+        payload = {
+            "name": name,
+            "maxThreads": max_threads,
+            "maxHash": max_hash_table_size,
+            "defaultDepth": default_depth,
+            "variants": variants,
+            "providerSecret": provider_secret,
+            "providerData": provider_data,
+        }
+        return self._r.put(path=path, payload=payload)
+
+    def delete(self, engine_id: str) -> None:
+        """Unregisters an external engine.
+
+        :param engine_id: engine ID
+        """
+        path = f"/api/external-engine/{engine_id}"
+        self._r.request("DELETE", path)

--- a/berserk/clients/external_engine.py
+++ b/berserk/clients/external_engine.py
@@ -6,6 +6,8 @@ from .base import BaseClient
 
 
 class ExternalEngine(BaseClient):
+    """Client for external engine related endpoints."""
+
     def get(self) -> Dict[str, Any]:
         """Lists all external engines that have been registered for the user, and the credentials required to use them.
 

--- a/berserk/clients/external_engine.py
+++ b/berserk/clients/external_engine.py
@@ -66,7 +66,7 @@ class ExternalEngine(BaseClient):
         provider_secret: str,
         variants: List[str] | None = None,
         provider_data: str | None = None,
-    ) -> Dict[str, Any]:
+    ) -> Any:
         """Updates the properties of an external engine.
 
         :param engine_id: engine ID
@@ -89,7 +89,7 @@ class ExternalEngine(BaseClient):
             "providerSecret": provider_secret,
             "providerData": provider_data,
         }
-        return self._r.put(path=path, payload=payload)
+        return self._r.request(method="PUT", path=path, payload=payload)
 
     def delete(self, engine_id: str) -> None:
         """Unregisters an external engine.

--- a/berserk/clients/external_engine.py
+++ b/berserk/clients/external_engine.py
@@ -8,16 +8,20 @@ from .base import BaseClient
 class ExternalEngine(BaseClient):
     """Client for external engine related endpoints."""
 
-    def get(self) -> Dict[str, Any]:
+    def get(self) -> List[ExternalEngine]:
         """Lists all external engines that have been registered for the user, and the credentials required to use them.
+
+        Requires OAuth2 authorization.
 
         :return: info about the external engines
         """
         path = "/api/external-engine"
         return self._r.get(path)
 
-    def get_by_id(self, engine_id: str) -> Dict[str, Any]:
+    def get_by_id(self, engine_id: str) -> ExternalEngine:
         """Get properties and credentials of an external engine.
+
+        Requires OAuth2 authorization.
 
         :param engine_id: external engine ID
         :return: info about the external engine
@@ -34,8 +38,10 @@ class ExternalEngine(BaseClient):
         provider_secret: str,
         variants: List[str] | None = None,
         provider_data: str | None = None,
-    ) -> Dict[str, Any]:
+    ) -> ExternalEngine:
         """Registers a new external engine for the user.
+
+        Requires OAuth2 authorization.
 
         :param name: engine display name
         :param max_threads: maximum number of available threads
@@ -68,8 +74,10 @@ class ExternalEngine(BaseClient):
         provider_secret: str,
         variants: List[str] | None = None,
         provider_data: str | None = None,
-    ) -> Any:
+    ) -> ExternalEngine:
         """Updates the properties of an external engine.
+
+        Requires OAuth2 authorization.
 
         :param engine_id: engine ID
         :param name: engine display name
@@ -95,6 +103,8 @@ class ExternalEngine(BaseClient):
 
     def delete(self, engine_id: str) -> None:
         """Unregisters an external engine.
+
+        Requires OAuth2 authorization.
 
         :param engine_id: engine ID
         """

--- a/berserk/types/__init__.py
+++ b/berserk/types/__init__.py
@@ -19,6 +19,7 @@ __all__ = [
     "BulkPairing",
     "BulkPairingGame",
     "ClockConfig",
+    "ExternalEngine",
     "LightUser",
     "OnlineLightUser",
     "CurrentTournaments",

--- a/berserk/types/__init__.py
+++ b/berserk/types/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from .account import AccountInformation, Perf, Preferences, Profile, StreamerInfo
 from .bulk_pairings import BulkPairing, BulkPairingGame
-from .common import ClockConfig, LightUser, OnlineLightUser
+from .common import ClockConfig, ExternalEngine, LightUser, OnlineLightUser
 from .puzzles import PuzzleRace
 from .opening_explorer import (
     OpeningExplorerRating,

--- a/berserk/types/common.py
+++ b/berserk/types/common.py
@@ -12,6 +12,27 @@ class ClockConfig(TypedDict):
     increment: int
 
 
+class ExternalEngine(TypedDict):
+    # Engine ID
+    id: str
+    # Engine display name
+    name: str
+    # Secret token that can be used to request analysis
+    clientSecret: str
+    # User this engine has been registered for
+    userId: str
+    # Max number of available threads
+    maxThreads: int
+    # Max available hash table size, in MiB
+    maxHash: int
+    # Estimated depth of normal search
+    defaultDepth: int
+    # List of supported chess variants
+    variants: str
+    # Arbitrary data that engine provider can use for identification or bookkeeping
+    providerData: NotRequired[str]
+
+
 Color: TypeAlias = Literal["white", "black"]
 
 GameType: TypeAlias = Literal[


### PR DESCRIPTION
## Description

Implements the following:
- `get` = GET `/api/external-engine`
- `get_by_id` = `/api/external-engines/{id}`
- `create` = POST `/api/external-engine`
-  `update` = PUT `/api/external-engine`
- `delete` = DEL `/api/external-engine`

Note that this PR does NOT include any of the endpoints that use a different domain than `https://lichess.org`.

## After merge

Please check off the above endpoints in the issue description for #6 🙏 
