### PR TITLE
Implement api/swiss endpoints

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,14 @@ Changelog
 To be released
 --------------
 
+* Add ``
+    client.tournaments.get_swiss
+    client.tournaments.update_swiss
+    client.tournaments.join_swiss
+    client.tournaments.terminate_swiss
+    client.tournaments.stream_swiss_results
+    client.tournaments.withdraw_swiss
+    client.tournaments.schedule_swiss_next_round``
 * Add ``client.puzzles.create_race``
 * Add ``client.users.get_by_autocomplete``
 

--- a/README.rst
+++ b/README.rst
@@ -177,15 +177,22 @@ Most of the API is available:
 
     client.tournaments.get
     client.tournaments.get_tournament
+    client.tournaments.get_swiss
     client.tournaments.create_arena
     client.tournaments.create_swiss
     client.tournaments.export_arena_games
     client.tournaments.export_swiss_games
     client.tournaments.arena_by_team
     client.tournaments.swiss_by_team
+    client.tournaments.join_swiss
+    client.tournaments.terminate_swiss
     client.tournaments.tournaments_by_user
     client.tournaments.stream_results
+    client.tournaments.stream_swiss_results
     client.tournaments.stream_by_creator
+    client.tournaments.update_swiss
+    client.tournaments.withdraw_swiss
+    client.tournaments.schedule_swiss_next_round
 
     client.tv.get_current_games
     client.tv.stream_current_game

--- a/berserk/__init__.py
+++ b/berserk/__init__.py
@@ -12,12 +12,15 @@ __version__ = berserk_metadata["Version"]
 
 from .clients import Client
 from .types import (
+    ArenaResult,
     Team,
-    OpeningStatistic,
-    PaginatedTeams,
     LightUser,
     OnlineLightUser,
+    OpeningStatistic,
+    PaginatedTeams,
     PuzzleRace,
+    SwissInfo,
+    SwissResult,
 )
 from .session import TokenSession
 from .session import Requestor
@@ -29,6 +32,7 @@ from .formats import NDJSON_LIST
 from .formats import PGN
 
 __all__ = [
+    "ArenaResult",
     "Client",
     "LightUser",
     "OnlineLightUser",
@@ -44,4 +48,6 @@ __all__ = [
     "NDJSON_LIST",
     "PGN",
     "PuzzleRace",
+    "SwissInfo",
+    "SwissResult",
 ]

--- a/berserk/clients/tournaments.py
+++ b/berserk/clients/tournaments.py
@@ -5,7 +5,7 @@ from typing import Iterator, Any, Dict, List, cast
 from .. import models
 from ..formats import NDJSON, NDJSON_LIST, PGN
 from .base import FmtClient
-from ..types.tournament import TournamentInfo, TournamentResult
+from ..types.tournament import SwissInfo, SwissResult
 
 
 class Tournaments(FmtClient):
@@ -301,7 +301,7 @@ class Tournaments(FmtClient):
 
     def stream_results(
         self, id: str, limit: int | None = None
-    ) -> Iterator[Dict[str, TournamentResult]]:
+    ) -> Iterator[Dict[str, SwissResult]]:
         """Stream the results of a tournament.
 
         Results are the players of a tournament with their scores and performance in
@@ -325,18 +325,18 @@ class Tournaments(FmtClient):
         path = f"/api/user/{username}/tournament/created"
         yield from self._r.get(path, stream=True)
 
-    def get_swiss_tournament_info(self, tournament_id: str) -> TournamentInfo:
+    def get_swiss_tournament_info(self, tournament_id: str) -> SwissInfo:
         """Get detailed info about a Swiss tournament.
 
         :param tournament_id: the Swiss tournament ID.
         :return: detailed info about a Swiss tournament
         """
         path = f"/api/swiss/{tournament_id}"
-        return cast(TournamentInfo, self._r.get(path))
+        return cast(SwissInfo, self._r.get(path))
 
     def get_swiss_tournament_result(
         self, tournament_id: str, limit: int | None = None
-    ) -> Iterator[Dict[str, TournamentResult]]:
+    ) -> Iterator[Dict[str, SwissResult]]:
         """Results are the players of a swiss tournament with their scores and performance in
         rank order. Note that results for ongoing tournaments can be inconsistent due to
         ranking changes.
@@ -344,7 +344,7 @@ class Tournaments(FmtClient):
         :param tournament_id: the Swiss tournament ID.
         :param limit: Max number of players to fetch
 
-        :return: iterator of the TournamentResult or an empty iterator if no result
+        :return: iterator of the SwissResult or an empty iterator if no result
         """
         path = f"/api/swiss/{tournament_id}/results"
         params = {"nb": limit}
@@ -375,7 +375,7 @@ class Tournaments(FmtClient):
         maxRating: int | None = None,
         nbRatedGame: int | None = None,
         allowList: str | None = None,
-    ) -> Dict[str, TournamentInfo]:
+    ) -> Dict[str, SwissInfo]:
         """Updata a swiss tournament.
 
         :param tournamentId : The unique identifier of the tournament to be updated.

--- a/berserk/clients/tournaments.py
+++ b/berserk/clients/tournaments.py
@@ -399,3 +399,15 @@ class Tournaments(FmtClient):
             "chatFor": chatFor,
         }
         return self._r.post(path, json=payload)
+
+    def join_swiss_by_id(
+        self, swiss_id: str, password: str | None = None
+    ) -> Dict[str, bool]:
+        """Join a Swiss tournament, possibly with a password.
+
+        :param swiss_id: the Swiss tournament ID.
+        :return: detailed info about a Swiss tournament
+        """
+        path = f"/api/swiss/{swiss_id}/join"
+        payload = {"password": password}
+        return self._r.post(path, json=payload)

--- a/berserk/clients/tournaments.py
+++ b/berserk/clients/tournaments.py
@@ -416,7 +416,7 @@ class Tournaments(FmtClient):
         }
         return self._r.post(path, json=payload)
 
-    def join_swiss_tournament(
+    def join_swiss(
         self, tournament_id: str, password: str | None = None
     ) -> Dict[str, bool]:
         """Join a Swiss tournament, possibly with a password.
@@ -428,7 +428,7 @@ class Tournaments(FmtClient):
         payload = {"password": password}
         return self._r.post(path, json=payload)
 
-    def terminate_swiss_tournament(self, tournament_id: str) -> Dict[str, bool]:
+    def terminate_swiss(self, tournament_id: str) -> Dict[str, bool]:
         """Terminate a Swiss tournament.
 
         :param tournament_id: the Swiss tournament ID.
@@ -437,7 +437,7 @@ class Tournaments(FmtClient):
         path = f"/api/swiss/{tournament_id}/terminate"
         return self._r.post(path)
 
-    def withdraw_swiss_tournament(self, tournament_id: str) -> Dict[str, bool]:
+    def withdraw_swiss(self, tournament_id: str) -> Dict[str, bool]:
         """Withdraw a Swiss tournament.
 
         :param tournament_id: the Swiss tournament ID.

--- a/berserk/clients/tournaments.py
+++ b/berserk/clients/tournaments.py
@@ -22,7 +22,7 @@ class Tournaments(FmtClient):
             self._r.get(path, converter=models.Tournament.convert_values),
         )
 
-    def get_tournament(self, tournament_id: str, page: int = 1):
+    def get_tournament(self, tournament_id: str, page: int = 1) -> Dict[str, Any]:
         """Get information about an arena.
 
         :param tournament_id
@@ -325,7 +325,7 @@ class Tournaments(FmtClient):
         path = f"/api/user/{username}/tournament/created"
         yield from self._r.get(path, stream=True)
 
-    def get_swiss_tournament_info(self, tournament_id: str) -> SwissInfo:
+    def get_swiss(self, tournament_id: str) -> SwissInfo:
         """Get detailed info about a Swiss tournament.
 
         :param tournament_id: the Swiss tournament ID.

--- a/berserk/clients/tournaments.py
+++ b/berserk/clients/tournaments.py
@@ -416,17 +416,26 @@ class Tournaments(FmtClient):
         }
         return self._r.post(path, json=payload)
 
-    def join_swiss_by_id(
+    def join_swiss_tournament(
         self, tournament_id: str, password: str | None = None
     ) -> Dict[str, bool]:
         """Join a Swiss tournament, possibly with a password.
 
         :param tournament_id: the Swiss tournament ID.
-        :return: detailed info about a Swiss tournament
+        :return: {"ok": true} with 200 status code if join successfully else {"error": <error message>} with 400 status code
         """
         path = f"/api/swiss/{tournament_id}/join"
         payload = {"password": password}
         return self._r.post(path, json=payload)
+
+    def terminate_swiss_tournament(self, tournament_id: str) -> Dict[str, bool]:
+        """Terminate a Swiss tournament.
+
+        :param tournament_id: the Swiss tournament ID.
+        :return: {"ok": true} with 200 status code if join successfully else {"error": <error message>} with 400 status code
+        """
+        path = f"/api/swiss/{tournament_id}/terminate"
+        return self._r.post(path)
 
     def schedule_next_round(
         self, tournament_id: str, schedule_time: int

--- a/berserk/clients/tournaments.py
+++ b/berserk/clients/tournaments.py
@@ -344,11 +344,16 @@ class Tournaments(FmtClient):
         :param tournament_id: the Swiss tournament ID.
         :param limit: Max number of players to fetch
 
-        :return: iterator of the TournamentResult
+        :return: iterator of the TournamentResult or an empty iterator if no result
         """
-        path = f"/api/swiss/{tournament_id}/result"
+        path = f"/api/swiss/{tournament_id}/results"
         params = {"nb": limit}
-        yield from self._r.get(path, params=params, stream=True)
+        try:
+            yield from self._r.get(path, params=params, stream=True)
+        except Exception as e:
+            # Currently, it will return an empty iterator, but it is better to show some error messages
+            # The issue also orrurs in all remaining function without error handling
+            return e
 
     def update_swiss(
         self,

--- a/berserk/clients/tournaments.py
+++ b/berserk/clients/tournaments.py
@@ -5,16 +5,16 @@ from typing import Iterator, Any, Dict, List, cast
 from .. import models
 from ..formats import NDJSON, NDJSON_LIST, PGN
 from .base import FmtClient
-from ..types import CurrentTournaments, SwissInfo, SwissResult
+from ..types import ArenaResult, CurrentTournaments, SwissInfo, SwissResult
 
 
 class Tournaments(FmtClient):
     """Client for tournament-related endpoints."""
 
     def get(self) -> CurrentTournaments:
-        """Get recently finished, ongoing, and upcoming tournaments.
+        """Get recently finished, ongoing, and upcoming arenas.
 
-        :return: current tournaments
+        :return: current arenas
         """
         path = "/api/tournament"
         return cast(
@@ -23,7 +23,7 @@ class Tournaments(FmtClient):
         )
 
     def get_tournament(self, tournament_id: str, page: int = 1):
-        """Get information about a tournament.
+        """Get information about an arena.
 
         :param tournament_id
         :return: tournament information
@@ -83,7 +83,7 @@ class Tournaments(FmtClient):
         :param minRating: Minimum rating to join
         :param maxRating: Maximum rating to join
         :param nbRatedGame: Min number of rated games required
-        :return: created tournament info
+        :return: created arena info
         """
         path = "/api/tournament"
         payload = {
@@ -122,7 +122,7 @@ class Tournaments(FmtClient):
         description: str | None = None,
         rated: bool | None = None,
         chatFor: int | None = None,
-    ) -> Dict[str, Any]:
+    ) -> Dict[str, Any]:  # Probably SwissInfo
         """Create a new swiss tournament.
 
         .. note::
@@ -145,7 +145,7 @@ class Tournaments(FmtClient):
         :param description: tournament description
         :param rated: whether the game affects player ratings
         :param chatFor: who can read and write in the chat
-        :return: created tournament info
+        :return: created swiss info
         """
         path = f"/api/swiss/new/{teamId}"
 
@@ -250,11 +250,11 @@ class Tournaments(FmtClient):
     def tournaments_by_user(
         self, username: str, nb: int | None = None
     ) -> List[Dict[str, Any]]:
-        """Get tournaments created by a user.
+        """Get arena tournaments created by a user.
 
         :param username: username
         :param nb: max number of tournaments to fetch
-        :return: tournaments
+        :return: arena tournaments info
         """
 
         path = f"/api/user/{username}/tournament/created"
@@ -272,7 +272,7 @@ class Tournaments(FmtClient):
 
         :param teamId: Id of the team
         :param maxT: how many tournaments to download
-        :return: tournaments
+        :return: arena tournaments
         """
         path = f"/api/team/{teamId}/arena"
         params = {
@@ -289,7 +289,7 @@ class Tournaments(FmtClient):
 
         :param teamId: Id of the team
         :param maxT: how many tournaments to download
-        :return: tournaments
+        :return: swiss tournaments
         """
         path = f"/api/team/{teamId}/swiss"
         params = {
@@ -301,7 +301,7 @@ class Tournaments(FmtClient):
 
     def stream_results(
         self, id: str, limit: int | None = None
-    ) -> Iterator[Dict[str, SwissResult]]:
+    ) -> Iterator[Dict[str, ArenaResult]]:
         """Stream the results of a tournament.
 
         Results are the players of a tournament with their scores and performance in
@@ -334,7 +334,7 @@ class Tournaments(FmtClient):
         path = f"/api/swiss/{tournament_id}"
         return cast(SwissInfo, self._r.get(path))
 
-    def get_swiss_tournament_result(
+    def stream_swiss_results(
         self, tournament_id: str, limit: int | None = None
     ) -> Iterator[Dict[str, SwissResult]]:
         """Results are the players of a swiss tournament with their scores and performance in

--- a/berserk/clients/tournaments.py
+++ b/berserk/clients/tournaments.py
@@ -348,12 +348,7 @@ class Tournaments(FmtClient):
         """
         path = f"/api/swiss/{tournament_id}/results"
         params = {"nb": limit}
-        try:
-            yield from self._r.get(path, params=params, stream=True)
-        except Exception as e:
-            # Currently, it will return an empty iterator, but it is better to show some error messages
-            # The issue also orrurs in all remaining function without error handling
-            return e
+        yield from self._r.get(path, params=params, stream=True)
 
     def update_swiss(
         self,

--- a/berserk/clients/tournaments.py
+++ b/berserk/clients/tournaments.py
@@ -5,20 +5,20 @@ from typing import Iterator, Any, Dict, List, cast
 from .. import models
 from ..formats import NDJSON, NDJSON_LIST, PGN
 from .base import FmtClient
-from ..types.tournament import SwissInfo, SwissResult
+from ..types import CurrentTournaments, SwissInfo, SwissResult
 
 
 class Tournaments(FmtClient):
     """Client for tournament-related endpoints."""
 
-    def get(self) -> models.CurrentTournaments:
+    def get(self) -> CurrentTournaments:
         """Get recently finished, ongoing, and upcoming tournaments.
 
         :return: current tournaments
         """
         path = "/api/tournament"
         return cast(
-            models.CurrentTournaments,
+            CurrentTournaments,
             self._r.get(path, converter=models.Tournament.convert_values),
         )
 

--- a/berserk/clients/tournaments.py
+++ b/berserk/clients/tournaments.py
@@ -416,45 +416,37 @@ class Tournaments(FmtClient):
         }
         return self._r.post(path, json=payload)
 
-    def join_swiss(
-        self, tournament_id: str, password: str | None = None
-    ) -> Dict[str, bool]:
+    def join_swiss(self, tournament_id: str, password: str | None = None) -> None:
         """Join a Swiss tournament, possibly with a password.
 
         :param tournament_id: the Swiss tournament ID.
-        :return: {"ok": true} with 200 status code if join successfully else {"error": <error message>} with 400 status code
         """
         path = f"/api/swiss/{tournament_id}/join"
         payload = {"password": password}
-        return self._r.post(path, json=payload)
+        self._r.post(path, json=payload)
 
-    def terminate_swiss(self, tournament_id: str) -> Dict[str, bool]:
+    def terminate_swiss(self, tournament_id: str) -> None:
         """Terminate a Swiss tournament.
 
         :param tournament_id: the Swiss tournament ID.
-        :return: {"ok": true} with 200 status code if join successfully else {"error": <error message>} with 400 status code
         """
         path = f"/api/swiss/{tournament_id}/terminate"
-        return self._r.post(path)
+        self._r.post(path)
 
-    def withdraw_swiss(self, tournament_id: str) -> Dict[str, bool]:
+    def withdraw_swiss(self, tournament_id: str) -> Nones:
         """Withdraw a Swiss tournament.
 
         :param tournament_id: the Swiss tournament ID.
-        :return: {"ok": true} with 200 status code if join successfully else {"error": <error message>} with 400 status code
         """
         path = f"/api/swiss/{tournament_id}/withdraw"
-        return self._r.post(path)
+        self._r.post(path)
 
-    def schedule_swiss_next_round(
-        self, tournament_id: str, schedule_time: int
-    ) -> None | Dict[str, str]:
+    def schedule_swiss_next_round(self, tournament_id: str, schedule_time: int) -> None:
         """Manually schedule the next round date and time of a Swiss tournament.
 
         :param tournament_id: the Swiss tournament ID.
         :schedule_time: Timestamp in milliseconds to start the next round at a given date and time.
-        :return: if schedule successfully, nothing would be returned. Otherwise, return the error messages
         """
         path = f"/api/swiss/{tournament_id}/schedule-next-round"
         payload = {"date": schedule_time}
-        return self._r.post(path, json=payload)
+        self._r.post(path, json=payload)

--- a/berserk/clients/tournaments.py
+++ b/berserk/clients/tournaments.py
@@ -325,7 +325,7 @@ class Tournaments(FmtClient):
         path = f"/api/user/{username}/tournament/created"
         yield from self._r.get(path, stream=True)
 
-    def get_swiss_info_by_id(self, tournament_id: str) -> TournamentInfo:
+    def get_swiss_tournament_info(self, tournament_id: str) -> TournamentInfo:
         """Get detailed info about a Swiss tournament.
 
         :param tournament_id: the Swiss tournament ID.
@@ -334,7 +334,7 @@ class Tournaments(FmtClient):
         path = f"/api/swiss/{tournament_id}"
         return cast(TournamentInfo, self._r.get(path))
 
-    def get_swiss_result_by_id(
+    def get_swiss_tournament_result(
         self, tournament_id: str, limit: int | None = None
     ) -> Iterator[Dict[str, TournamentResult]]:
         """Results are the players of a swiss tournament with their scores and performance in
@@ -435,6 +435,15 @@ class Tournaments(FmtClient):
         :return: {"ok": true} with 200 status code if join successfully else {"error": <error message>} with 400 status code
         """
         path = f"/api/swiss/{tournament_id}/terminate"
+        return self._r.post(path)
+
+    def withdraw_swiss_tournament(self, tournament_id: str) -> Dict[str, bool]:
+        """Withdraw a Swiss tournament.
+
+        :param tournament_id: the Swiss tournament ID.
+        :return: {"ok": true} with 200 status code if join successfully else {"error": <error message>} with 400 status code
+        """
+        path = f"/api/swiss/{tournament_id}/withdraw"
         return self._r.post(path)
 
     def schedule_next_round(

--- a/berserk/clients/tournaments.py
+++ b/berserk/clients/tournaments.py
@@ -433,7 +433,7 @@ class Tournaments(FmtClient):
         path = f"/api/swiss/{tournament_id}/terminate"
         self._r.post(path)
 
-    def withdraw_swiss(self, tournament_id: str) -> Nones:
+    def withdraw_swiss(self, tournament_id: str) -> None:
         """Withdraw a Swiss tournament.
 
         :param tournament_id: the Swiss tournament ID.

--- a/berserk/clients/tournaments.py
+++ b/berserk/clients/tournaments.py
@@ -5,6 +5,7 @@ from typing import Iterator, Any, Dict, List, cast
 from .. import models
 from ..formats import NDJSON, NDJSON_LIST, PGN
 from .base import FmtClient
+from ..types.tournament import TournamentInfo
 
 
 class Tournaments(FmtClient):
@@ -323,3 +324,78 @@ class Tournaments(FmtClient):
         """
         path = f"/api/user/{username}/tournament/created"
         yield from self._r.get(path, stream=True)
+
+    def get_swiss_info_by_id(self, swiss_id: str) -> TournamentInfo:
+        """Get detailed info about a Swiss tournament.
+
+        :param swiss_id: the Swiss tournament ID.
+        :return: detailed info about a Swiss tournament
+        """
+        path = f"/api/swiss/{swiss_id}"
+        return cast(TournamentInfo, self._r.get(path))
+
+    def update_swiss(
+        self,
+        tournamentId: str,
+        clockLimit: int,
+        clockIncrement: int,
+        nbRounds: int,
+        startsAt: int | None = None,
+        roundInterval: int | None = None,
+        variant: str | None = None,
+        description: str | None = None,
+        name: str | None = None,
+        rated: bool | None = True,
+        password: str | None = None,
+        forbiddenPairings: str | None = None,
+        manualPairings: str | None = None,
+        chatFor: int | None = 20,
+        minRating: int | None = None,
+        maxRating: int | None = None,
+        nbRatedGame: int | None = None,
+        allowList: str | None = None,
+    ) -> Dict[str, TournamentInfo]:
+        """Updata a swiss tournament.
+
+        :param tournamentId : The unique identifier of the tournament to be updated.
+        :param clockLimit : The time limit for each player's clock.
+        :param clockIncrement : The time increment added to a player's clock after each move.
+        :param nbRounds : The number of rounds in the tournament.
+        :param startsAt : The start time of the tournament in Unix timestamp format.
+        :param roundInterval :The time interval between rounds in minutes.
+        :param variant :The chess variant of the tournament.
+        :param description : A description of the tournament.
+        :param name : The name of the tournament.
+        :param rated : Whether the tournament is rated.
+        :param password : A password to access the tournament.
+        :param forbiddenPairings : Specify forbidden pairings in the tournament.
+        :param manualPairings : Specify manual pairings for the tournament.
+        :param chatFor :The duration for which the chat is available in minutes.
+        :param minRating : The minimum rating required to participate in the tournament.
+        :param maxRating : The maximum rating allowed to participate in the tournament.
+        :param nbRatedGame : The number of rated games required for participation.
+        :param allowList : Specify an allow list for the tournament.
+        :return A dictionary containing information about the updated Swiss tournament.
+        """
+        path = f"/api/swiss/{tournamentId}/edit/"
+
+        payload = {
+            "name": name,
+            "clock.limit": clockLimit,
+            "clock.increment": clockIncrement,
+            "nbRounds": nbRounds,
+            "startsAt": startsAt,
+            "roundInterval": roundInterval,
+            "variant": variant,
+            "description": description,
+            "rated": rated,
+            "password": password,
+            "forbiddenPairings": forbiddenPairings,
+            "manualPairings": manualPairings,
+            "conditions.minRating.rating": minRating,
+            "conditions.maxRating.rating": maxRating,
+            "conditions.nbRatedGame.nb": nbRatedGame,
+            "conditions.allowList": allowList,
+            "chatFor": chatFor,
+        }
+        return self._r.post(path, json=payload)

--- a/berserk/clients/tournaments.py
+++ b/berserk/clients/tournaments.py
@@ -446,7 +446,7 @@ class Tournaments(FmtClient):
         path = f"/api/swiss/{tournament_id}/withdraw"
         return self._r.post(path)
 
-    def schedule_next_round(
+    def schedule_swiss_next_round(
         self, tournament_id: str, schedule_time: int
     ) -> None | Dict[str, str]:
         """Manually schedule the next round date and time of a Swiss tournament.

--- a/berserk/models.py
+++ b/berserk/models.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List, Tuple, TypeVar, TypedDict, overload
+from typing import Dict, List, Tuple, TypeVar, overload
 
 from . import utils
 
@@ -97,9 +97,3 @@ class OAuth(Model):
 class TV(Model):
     createdAt = utils.datetime_from_millis
     lastMoveAt = utils.datetime_from_millis
-
-
-class CurrentTournaments(TypedDict):
-    created: List[Dict[str, Any]]
-    started: List[Dict[str, Any]]
-    finished: List[Dict[str, Any]]

--- a/berserk/types/__init__.py
+++ b/berserk/types/__init__.py
@@ -11,6 +11,7 @@ from .opening_explorer import (
     Speed,
 )
 from .team import PaginatedTeams, Team
+from .tournaments import CurrentTournaments, SwissResult, SwissInfo
 
 __all__ = [
     "AccountInformation",
@@ -19,6 +20,7 @@ __all__ = [
     "ClockConfig",
     "LightUser",
     "OnlineLightUser",
+    "CurrentTournaments",
     "OpeningExplorerRating",
     "OpeningExplorerVariant",
     "OpeningStatistic",
@@ -29,5 +31,7 @@ __all__ = [
     "PuzzleRace",
     "Speed",
     "StreamerInfo",
+    "SwissInfo",
+    "SwissResult",
     "Team",
 ]

--- a/berserk/types/__init__.py
+++ b/berserk/types/__init__.py
@@ -11,10 +11,11 @@ from .opening_explorer import (
     Speed,
 )
 from .team import PaginatedTeams, Team
-from .tournaments import CurrentTournaments, SwissResult, SwissInfo
+from .tournaments import ArenaResult, CurrentTournaments, SwissResult, SwissInfo
 
 __all__ = [
     "AccountInformation",
+    "ArenaResult",
     "BulkPairing",
     "BulkPairingGame",
     "ClockConfig",

--- a/berserk/types/tournament.py
+++ b/berserk/types/tournament.py
@@ -1,4 +1,4 @@
-from typing import TypedDict
+from typing import TypedDict, Union
 
 
 class Clock(TypedDict):
@@ -29,4 +29,4 @@ class TournamentInfo(TypedDict):
     nbOngoing: int
     status: str
     rated: bool
-    stats: Stats | None
+    stats: Union[Stats, None]

--- a/berserk/types/tournament.py
+++ b/berserk/types/tournament.py
@@ -30,3 +30,12 @@ class TournamentInfo(TypedDict):
     status: str
     rated: bool
     stats: Union[Stats, None]
+
+
+class TournamentResult(TypedDict):
+    rank: int
+    points: int
+    tieBreak: float
+    rating: int
+    userName: str
+    performance: int

--- a/berserk/types/tournament.py
+++ b/berserk/types/tournament.py
@@ -1,0 +1,32 @@
+from typing import TypedDict
+
+
+class Clock(TypedDict):
+    limit: int
+    increment: int
+
+
+class Stats(TypedDict):
+    absences: int
+    averageRating: int
+    blackWins: int
+    byes: int
+    draws: int
+    games: int
+    whiteWins: int
+
+
+class TournamentInfo(TypedDict):
+    id: str
+    createdBy: str
+    startsAt: str
+    name: str
+    clock: Clock
+    variant: str
+    round: int
+    nbRounds: int
+    nbPlayers: int
+    nbOngoing: int
+    status: str
+    rated: bool
+    stats: Stats | None

--- a/berserk/types/tournament.py
+++ b/berserk/types/tournament.py
@@ -16,7 +16,7 @@ class Stats(TypedDict):
     whiteWins: int
 
 
-class TournamentInfo(TypedDict):
+class SwissInfo(TypedDict):
     id: str
     createdBy: str
     startsAt: str
@@ -32,7 +32,7 @@ class TournamentInfo(TypedDict):
     stats: Union[Stats, None]
 
 
-class TournamentResult(TypedDict):
+class SwissResult(TypedDict):
     rank: int
     points: int
     tieBreak: float

--- a/berserk/types/tournaments.py
+++ b/berserk/types/tournaments.py
@@ -1,4 +1,12 @@
-from typing import TypedDict, Union
+from typing import Any, List, Dict
+
+from typing_extensions import TypedDict
+
+
+class CurrentTournaments(TypedDict):
+    created: List[Dict[str, Any]]
+    started: List[Dict[str, Any]]
+    finished: List[Dict[str, Any]]
 
 
 class Clock(TypedDict):
@@ -29,7 +37,7 @@ class SwissInfo(TypedDict):
     nbOngoing: int
     status: str
     rated: bool
-    stats: Union[Stats, None]
+    stats: Stats | None
 
 
 class SwissResult(TypedDict):

--- a/berserk/types/tournaments.py
+++ b/berserk/types/tournaments.py
@@ -1,6 +1,7 @@
 from typing import Any, List, Dict
 
-from typing_extensions import TypedDict
+from .common import Title
+from typing_extensions import TypedDict, NotRequired
 
 
 class CurrentTournaments(TypedDict):
@@ -40,10 +41,19 @@ class SwissInfo(TypedDict):
     stats: Stats | None
 
 
-class SwissResult(TypedDict):
+# private, abstract class
+class TournamentResult(TypedDict):
     rank: int
+    rating: int
+    username: str
+    title: NotRequired[Title]
+    performance: int
+
+
+class ArenaResult(TournamentResult):
+    score: int
+
+
+class SwissResult(TournamentResult):
     points: int
     tieBreak: float
-    rating: int
-    userName: str
-    performance: int

--- a/berserk/types/tournaments.py
+++ b/berserk/types/tournaments.py
@@ -55,5 +55,5 @@ class ArenaResult(TournamentResult):
 
 
 class SwissResult(TournamentResult):
-    points: int
+    points: float  # can be .5 in case of draw
     tieBreak: float

--- a/berserk/types/tournaments.py
+++ b/berserk/types/tournaments.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Dict
+from typing import Any, List, Dict, Optional
 
 from .common import Title
 from typing_extensions import TypedDict, NotRequired
@@ -38,7 +38,7 @@ class SwissInfo(TypedDict):
     nbOngoing: int
     status: str
     rated: bool
-    stats: Stats | None
+    stats: Optional[Stats]
 
 
 # private, abstract class

--- a/tests/clients/cassettes/test_tournaments/TestLichessGames.test_arenas_result.yaml
+++ b/tests/clients/cassettes/test_tournaments/TestLichessGames.test_arenas_result.yaml
@@ -1,0 +1,54 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://lichess.org/api/tournament/hallow23/results?nb=3
+  response:
+    body:
+      string: '{"rank":1,"score":149,"rating":2394,"username":"GGbers","performance":2449}
+
+        {"rank":2,"score":124,"rating":2346,"username":"Kondor75","title":"IM","performance":2447}
+
+        {"rank":3,"score":123,"rating":2241,"username":"sadisticTushi","performance":2314}
+
+        '
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Authorization, If-Modified-Since, Cache-Control, Content-Type
+      Access-Control-Allow-Methods:
+      - OPTIONS, GET, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Disposition:
+      - attachment; filename=lichess_tournament_2023.10.31_hallow23_halloween-arena-2023.ndjson
+      Content-Type:
+      - application/x-ndjson
+      Date:
+      - Tue, 31 Oct 2023 21:10:24 GMT
+      Permissions-Policy:
+      - interest-cohort=()
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/clients/cassettes/test_tournaments/TestLichessGames.test_swiss_result.yaml
+++ b/tests/clients/cassettes/test_tournaments/TestLichessGames.test_swiss_result.yaml
@@ -1,0 +1,54 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://lichess.org/api/swiss/ADAHHiMX/results?nb=3
+  response:
+    body:
+      string: '{"rank":1,"points":6,"tieBreak":20.5,"rating":2150,"username":"MorphyTal2018","performance":2390}
+
+        {"rank":2,"points":6,"tieBreak":19.75,"rating":2286,"username":"I_Eat_Chess","performance":2459}
+
+        {"rank":3,"points":5.5,"tieBreak":16.5,"rating":2309,"username":"Prajurit_CSI","performance":2352}
+
+        '
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Authorization, If-Modified-Since, Cache-Control, Content-Type
+      Access-Control-Allow-Methods:
+      - OPTIONS, GET, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Disposition:
+      - attachment; filename=lichess_swiss_2023.10.31_ADAHHiMX_rapid.ndjson
+      Content-Type:
+      - application/x-ndjson
+      Date:
+      - Tue, 31 Oct 2023 22:09:05 GMT
+      Permissions-Policy:
+      - interest-cohort=()
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/clients/test_tournaments.py
+++ b/tests/clients/test_tournaments.py
@@ -1,0 +1,19 @@
+import pytest
+
+from berserk import ArenaResult, Client, SwissInfo, SwissResult
+from typing import List
+from utils import validate, skip_if_older_3_dot_10
+
+
+class TestLichessGames:
+    @skip_if_older_3_dot_10
+    @pytest.mark.vcr
+    def test_swiss_result(self):
+        res = list(Client().tournaments.stream_swiss_results("ADAHHiMX", limit=3))
+        validate(List[SwissResult], res)
+
+    @skip_if_older_3_dot_10
+    @pytest.mark.vcr
+    def test_arenas_result(self):
+        res = list(Client().tournaments.stream_results("hallow23", limit=3))
+        validate(List[ArenaResult], res)

--- a/tests/clients/utils.py
+++ b/tests/clients/utils.py
@@ -17,7 +17,7 @@ def validate(t: type, value: any):
     class TWithConfig(t):
         __pydantic_config__ = config
 
-    print(value)
+    print("value", value)
     try:
         # In case `t` is a `TypedDict`
         return TypeAdapter(TWithConfig).validate_python(value)


### PR DESCRIPTION
1. Add all the remaining swiss endpoints:
`get_swiss_tournament_info `= `/api/swiss/{swiss_id}`
`update_swiss` = `api/swiss/{tournamentId}/edit`
`join_swiss_tournament` = `/api/swiss/{id}/join`
`get_swiss_tournament_result` = `/api/swiss/{id}/results`
`schedule_next_round` = `/api/swiss/{id}/schedule-next-round`
`terminate_swiss_tournament` = `/api/swiss/{id}/terminate`
`withdraw_swiss_tournament` = `/api/swiss/{id}/withdraw`

2. Add missing return type for tournament
