### PR TITLE
Implement `/swiss/{id}.trf` endpoint

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ To be released
 
     client.analysis.get_cloud_evaluation
 
+    client.tournaments.export_swiss_trf
+
 Thanks to @Anupya for their contributions to this release.
 
 v0.13.1 (2023-11-02)

--- a/README.rst
+++ b/README.rst
@@ -199,6 +199,7 @@ Most of the API is available:
     client.tournaments.create_swiss
     client.tournaments.export_arena_games
     client.tournaments.export_swiss_games
+    client.tournaments.export_swiss_trf
     client.tournaments.arena_by_team
     client.tournaments.swiss_by_team
     client.tournaments.join_arena

--- a/berserk/clients/tournaments.py
+++ b/berserk/clients/tournaments.py
@@ -301,6 +301,15 @@ class Tournaments(FmtClient):
                 converter=models.Game.convert,
             )
 
+    def export_swiss_trf(self, tournament_id: str) -> str:
+        """Download a tournament in the Tournament Report File format, the FIDE standard.
+
+        :param tournament_id: tournament ID
+        :return: tournament information in the TRF format
+        """
+        path = f"/swiss/{tournament_id}.trf"
+        return self._r.get(path)
+
     def tournaments_by_user(
         self, username: str, nb: int | None = None
     ) -> List[Dict[str, Any]]:

--- a/berserk/clients/tournaments.py
+++ b/berserk/clients/tournaments.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Iterator, Any, Dict, List, cast
 
 from .. import models
-from ..formats import NDJSON, NDJSON_LIST, PGN
+from ..formats import NDJSON, NDJSON_LIST, PGN, TEXT
 from .base import FmtClient
 from ..types import ArenaResult, CurrentTournaments, SwissInfo, SwissResult
 from ..types.tournaments import TeamBattleResult
@@ -308,7 +308,7 @@ class Tournaments(FmtClient):
         :return: tournament information in the TRF format
         """
         path = f"/swiss/{tournament_id}.trf"
-        return self._r.get(path)
+        return self._r.get(path=path, fmt=TEXT)
 
     def tournaments_by_user(
         self, username: str, nb: int | None = None


### PR DESCRIPTION
## Description

- Implement `/swiss/{id}.trf`
   - I am not sure how to define a return type `TRF` (as it is not JSON formattable), so the endpoint's return type will be `str`.
   - This is the reason I did not include a test as the API endpoint does not return JSON.

## After merge

Check off `/swiss/{id}.trf` in #6.

## Checklist

<details>
<summary>Checklist when adding a new endpoint</summary>


<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [X] Added new endpoint to the `README.md`
- [X] Ensure that my endpoint name does not repeat the name of the client. Wrong: `client.users.get_user()`, Correct: `client.users.get()`
- [ ] Typed the returned JSON using TypedDicts in `berserk/types/`, [example](https://github.com/lichess-org/berserk/blob/master/berserk/types/team.py#L32) **<--not returning JSON so not relevant**
- [ ] Tested GET endpoints not requiring authentification. [Documentation](https://github.com/lichess-org/berserk/blob/master/CONTRIBUTING.rst#using-pytest-recording--vcrpy), [example](https://github.com/lichess-org/berserk/blob/master/tests/clients/test_teams.py#L11) **<--not returning JSON so not relevant**
- [ ] Added the endpoint and your name to `CHANGELOG.md` in the `To be released` section (to be created if necessary)  **<--leaving it up to the maintainer**
</details>