### PR TITLE
Correction in check-endpoints.py

### DIFF
--- a/check-endpoints.py
+++ b/check-endpoints.py
@@ -34,7 +34,7 @@ for endpoint, data in spec["paths"].items():
     endpoint_without_slash = endpoint[1:]
 
     # Replace parameter placeholders with regular expression
-    endpoint_regex = '"/' + re.sub(r"{[^/]+?}", r"[^/]+?", endpoint_without_slash) + '"'
+    endpoint_regex = r'/' + re.sub(r"{[^/]+?}", r"[^/]+?", endpoint_without_slash)
 
     # Check if endpoint or a variation of it is present in file
     if not re.search(endpoint_regex, clients_content):


### PR DESCRIPTION
Changed the search regex from '"/' + re.sub(r"{[^/]+?}", r"[^/]+?", endpoint_without_slash) + '"' to r'/' + re.sub(r"{[^/]+?}", r"[^/]+?", endpoint_without_slash) so that false negatives like claim-victory do not showup