### PR TITLE
Move kick team member to /api/

### DIFF
--- a/berserk/clients/teams.py
+++ b/berserk/clients/teams.py
@@ -51,7 +51,7 @@ class Teams(BaseClient):
         :param team_id: ID of the team to kick from
         :param user_id: ID of the user to kick from the team
         """
-        path = f"/team/{team_id}/kick/{user_id}"
+        path = f"/api/team/{team_id}/kick/{user_id}"
         self._r.post(path)
 
     def get_join_requests(


### PR DESCRIPTION
Heads up!

lichess-org/lila@9ee36b18
The endpoint has been moved, so next lila deploy, old scripts won't work any longer...
```
    /team/:id/kick/:user   controllers.Team.kickUser(id, user)

->

/api/team/:id/kick/:user   controllers.TeamApi.kickUser(id, user)
```

Thoughts about compatibility:
- I guess one could "ask" lichess to keep the old endpoint around for a bit to give users a chance to adapt...
- I guess one could make a berserk version which knows both endpoints "if 404, try new endpoint", so it is possible to release berserk even before next lila deploy and any user running latest berserk will never see a problem
- ... or one could try to keep things simple and let the risk of someone running into a problem happen :sweat_smile: 