### PR TITLE
Adding `import_pgn` endpoints

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+To be released
+--------------
+
+* Added ``studies.import_pgn`` to import PGN to study
+
 v0.13.2 (2023-12-04)
 --------------------
 

--- a/README.rst
+++ b/README.rst
@@ -170,6 +170,7 @@ Most of the API is available:
     client.studies.export_chapter
     client.studies.export
     client.studies.export_by_username
+    client.studies.import_pgn
 
     client.tablebase.look_up
     client.tablebase.standard

--- a/berserk/__init__.py
+++ b/berserk/__init__.py
@@ -16,6 +16,7 @@ from .types import (
     BroadcastPlayer,
     Team,
     LightUser,
+    ChapterIdName,
     OnlineLightUser,
     OpeningStatistic,
     PaginatedTeams,
@@ -35,6 +36,7 @@ from .formats import PGN
 __all__ = [
     "ArenaResult",
     "BroadcastPlayer",
+    "ChapterIdName",
     "Client",
     "JSON",
     "JSON_LIST",

--- a/berserk/clients/studies.py
+++ b/berserk/clients/studies.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
-from typing import Dict, Iterator
+from typing import Iterator
 
 from ..formats import PGN
+from ..types.common import Color, Variant
+from ..types import ChapterIdName
 from .base import BaseClient
 
 
@@ -41,11 +43,15 @@ class Studies(BaseClient):
         study_id: str,
         chapter_name: str,
         pgn: str,
-        orientation: str = "white",
-        variant: str = "standard",
-    ) -> Iterator[Dict[str, str]]:
+        orientation: Color = "white",
+        variant: Variant = "standard",
+    ) -> list[ChapterIdName]:
         """Imports arbitrary PGN into an existing study.
         Creates a new chapter in the study.
+
+        If the PGN contains multiple games (separated by 2 or more newlines) then multiple chapters will be created within the study.
+
+        Note that a study can contain at most 64 chapters.
 
         return: Iterator over the chapter {id, name}"""
         # https://lichess.org/api/study/{studyId}/import-pgn
@@ -57,5 +63,4 @@ class Studies(BaseClient):
             "variant": variant,
         }
         # The return is of the form:
-        # {chapters:[{id: "chapterId", name: "chapterName"}]}
-        yield from (c for c in self._r.post(path, data=payload).get("chapters", []))
+        return self._r.post(path, data=payload).get("chapters", [])

--- a/berserk/clients/studies.py
+++ b/berserk/clients/studies.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Iterator
+from typing import cast, Iterator
 
 from ..formats import PGN
 from ..types.common import Color, Variant
@@ -53,7 +53,7 @@ class Studies(BaseClient):
 
         Note that a study can contain at most 64 chapters.
 
-        return: Iterator over the chapter {id, name}"""
+        return: List of the chapters {id, name}"""
         # https://lichess.org/api/study/{studyId}/import-pgn
         path = f"/api/study/{study_id}/import-pgn"
         payload = {
@@ -63,4 +63,6 @@ class Studies(BaseClient):
             "variant": variant,
         }
         # The return is of the form:
-        return self._r.post(path, data=payload).get("chapters", [])
+        return cast(
+            list[ChapterIdName], self._r.post(path, data=payload).get("chapters", [])
+        )

--- a/berserk/clients/studies.py
+++ b/berserk/clients/studies.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import cast, Iterator
+from typing import cast, List, Iterator
 
 from ..formats import PGN
 from ..types.common import Color, Variant
@@ -45,7 +45,7 @@ class Studies(BaseClient):
         pgn: str,
         orientation: Color = "white",
         variant: Variant = "standard",
-    ) -> list[ChapterIdName]:
+    ) -> List[ChapterIdName]:
         """Imports arbitrary PGN into an existing study.
         Creates a new chapter in the study.
 
@@ -64,5 +64,5 @@ class Studies(BaseClient):
         }
         # The return is of the form:
         return cast(
-            list[ChapterIdName], self._r.post(path, data=payload).get("chapters", [])
+            List[ChapterIdName], self._r.post(path, data=payload).get("chapters", [])
         )

--- a/berserk/clients/studies.py
+++ b/berserk/clients/studies.py
@@ -37,8 +37,12 @@ class Studies(BaseClient):
         yield from self._r.get(path, fmt=PGN, stream=True)
 
     def import_pgn(
-        self, study_id: str, chapter_name: str, pgn: str,
-        orientation: str = "white", variant: str = "standard"
+        self,
+        study_id: str,
+        chapter_name: str,
+        pgn: str,
+        orientation: str = "white",
+        variant: str = "standard",
     ) -> Iterator[Dict[str, str]]:
         """Imports arbitrary PGN into an existing study.
         Creates a new chapter in the study.
@@ -54,6 +58,4 @@ class Studies(BaseClient):
         }
         # The return is of the form:
         # {chapters:[{id: "chapterId", name: "chapterName"}]}
-        yield from (
-            c for c in self._r.post(path, data=payload).get("chapters", [])
-        )
+        yield from (c for c in self._r.post(path, data=payload).get("chapters", []))

--- a/berserk/types/__init__.py
+++ b/berserk/types/__init__.py
@@ -11,6 +11,7 @@ from .opening_explorer import (
     OpeningStatistic,
     Speed,
 )
+from .studies import ChapterIdName
 from .team import PaginatedTeams, Team
 from .tournaments import ArenaResult, CurrentTournaments, SwissResult, SwissInfo
 
@@ -21,6 +22,7 @@ __all__ = [
     "BulkPairing",
     "BulkPairingGame",
     "Challenge",
+    "ChapterIdName",
     "ClockConfig",
     "CurrentTournaments",
     "ExternalEngine",

--- a/berserk/types/studies.py
+++ b/berserk/types/studies.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from typing_extensions import TypedDict
+
+
+class ChapterIdName(TypedDict):
+    id: str
+    name: str


### PR DESCRIPTION
Hi there,

Thanks for the project!   This small PR add the `study/ImportPGN` endpoint.

https://lichess.org/api#tag/Studies/operation/apiStudyImportPGN

Testing with:

```python
  session = berserk.TokenSession(API_TOKEN)
  client = berserk.Client(session=session)
  resp = client.studies.import_pgn(
      study_id=STUDY_ID,
      chapter_name="test",
      pgn=PGN,
      orientation="white",
  )
  for chapter in resp:
      print(chapter)
```

Returning the imported chapters.
```
{'id': 'oavP10Ig', 'name': 'test'}
```

<details>
<summary>Checklist when adding a new endpoint</summary>


- [x] Added new endpoint to the `README.md`
- [x] Ensure that my endpoint name does not repeat the name of the client. Wrong: `client.users.get_user()`, Correct: `client.users.get()`
- [x] Typed the returned JSON using TypedDicts in `berserk/types/`, [example](https://github.com/lichess-org/berserk/blob/master/berserk/types/team.py#L32)
- [ ] ~Tested GET endpoints not requiring authentification. [Documentation](https://github.com/lichess-org/berserk/blob/master/CONTRIBUTING.rst#using-pytest-recording--vcrpy), [example](https://github.com/lichess-org/berserk/blob/master/tests/clients/test_teams.py#L11)~
- [x] Added the endpoint and your name to `CHANGELOG.md` in the `To be released` section (to be created if necessary)
</details>
