### PR TITLE
I changed the broken datetime _from_millis into timedelta_from_milis.…

### DIFF
--- a/berserk/models.py
+++ b/berserk/models.py
@@ -68,8 +68,8 @@ class Game(Model):
 
 class GameState(Model):
     createdAt = utils.datetime_from_millis
-    wtime = utils.datetime_from_millis
-    btime = utils.datetime_from_millis
+    wtime = utils.timedelta_from_milis
+    btime = utils.timedelta_from_milis
     winc = utils.datetime_from_millis
     binc = utils.datetime_from_millis
 

--- a/berserk/utils.py
+++ b/berserk/utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import dateutil.parser
 
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 from typing import Any, Callable, Dict, List, NamedTuple, Tuple, TypeVar, Union, cast
 from .types.broadcast import BroadcastPlayer
 
@@ -15,6 +15,11 @@ def to_millis(dt: datetime) -> int:
     return int(dt.timestamp() * 1000)
 
 
+def timedelta_from_millis(millis: float) -> timedelta:
+    """Return a timedelta (A duration expressing the difference between two datetime or date instances to microsecond resolution.)
+    for a given milliseconds.
+    """
+    return timedelta(milliseconds=millis)
 def datetime_from_seconds(ts: float) -> datetime:
     """Return the datetime for the given seconds since the epoch.
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -8,3 +8,18 @@ def test_conversion():
     original = {"foo": "5", "bar": 3, "baz": "4"}
     modified = {"foo": 5, "bar": 3, "baz": "4"}
     assert Example.convert(original) == modified
+
+def test_time_delta():
+    """test timedelta_from millis"""
+    test_data = 1000.0
+    dt1 = datetime_from_millis(test_data)
+    dt2 = datetime_from_millis(2 * test_data)
+
+    delta_1 = timedelta_from_millis(test_data)
+
+    # time delta dt1 dt2
+    delta_2 = dt2 - dt1
+
+    assert delta_1 == delta_2
+
+


### PR DESCRIPTION
… Still must be testet, but works on my my machine

<!-- Describe your pull request here.-->
Hello, I am the guy from the gh issue where datetime is not a constructive unit for the game time. 

Due to not having a history w the codebase, it is just a jumping off point.

<details>
added:
```
    wtime = utils.timedelta_from_milis
    btime = utils.timedelta_from_milis
```
and the convieniance function:
```
def timedelta_from_millis(millis: float) -> timedelta:
    """Return a timedelta (A duration expressing the difference between two datetime or date instances to microsecond resolution.)
    for a given milliseconds.
    """
    return timedelta(milliseconds=millis)
```

<summary>Checklist when adding a new endpoint</summary>


<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] Added new endpoint to the `README.md`
- [ ] Ensure that my endpoint name does not repeat the name of the client. Wrong: `client.users.get_user()`, Correct: `client.users.get()`
- [ ] Typed the returned JSON using TypedDicts in `berserk/types/`, [example](https://github.com/lichess-org/berserk/blob/master/berserk/types/team.py#L32)
- [ ] Tested GET endpoints not requiring authentification. [Documentation](https://github.com/lichess-org/berserk/blob/master/CONTRIBUTING.rst#using-pytest-recording--vcrpy), [example](https://github.com/lichess-org/berserk/blob/master/tests/clients/test_teams.py#L11)
- [ ] Added the endpoint and your name to `CHANGELOG.md` in the `To be released` section (to be created if necessary)
</details>