### PR TITLE
Implement `/tv/{channel}/feed` endpoint

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,9 +7,9 @@ To be released
 * Fixed ``wbtime`` and ``btime`` for all endpoints returning a ``GameState``.
 * Added ``sheet`` optional parameter to ``Tournaments.stream_results``, and fix returned typed dict.
 * Added ``studies.import_pgn`` to import PGN to study
+* Added ``tv.stream_current_game_of_channel`` to stream the current TV game of a channel
 
-
-Thanks to @nicvagn, @tors42 and @fitztrev for their contributions to this release.
+Thanks to @nicvagn, @tors42, @fitztrev and @trevorbayless for their contributions to this release.
 
 v0.13.2 (2023-12-04)
 --------------------

--- a/README.rst
+++ b/README.rst
@@ -217,6 +217,7 @@ Most of the API is available:
 
     client.tv.get_current_games
     client.tv.stream_current_game
+    client.tv.stream_current_game_of_channel
     client.tv.get_best_ongoing
 
     client.users.get_realtime_statuses

--- a/berserk/__init__.py
+++ b/berserk/__init__.py
@@ -23,6 +23,7 @@ from .types import (
     PuzzleRace,
     SwissInfo,
     SwissResult,
+    TVFeed,
 )
 from .session import TokenSession
 from .session import Requestor
@@ -54,4 +55,5 @@ __all__ = [
     "SwissResult",
     "Team",
     "TokenSession",
+    "TVFeed",
 ]

--- a/berserk/clients/tv.py
+++ b/berserk/clients/tv.py
@@ -26,6 +26,15 @@ class TV(FmtClient):
         path = "/api/tv/feed"
         yield from self._r.get(path, stream=True)
 
+    def stream_current_game_of_channel(self, channel: str) -> Iterator[Dict[str, Any]]:
+        """Streams the current TV game of a channel.
+
+        :param channel: the TV channel to stream.
+        :return: positions and moves of the channels current TV game
+        """
+        path = f"/api/tv/{channel}/feed"
+        yield from self._r.get(path, stream=True)
+
     def get_best_ongoing(
         self,
         channel: str,

--- a/berserk/clients/tv.py
+++ b/berserk/clients/tv.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from typing import Any, Iterator, Dict, List
+from typing import Any, Iterator, Dict, List, cast
 
 from .. import models
 from ..formats import NDJSON_LIST, PGN
+from ..types import TVFeed
 from .base import FmtClient
 
 
@@ -18,22 +19,24 @@ class TV(FmtClient):
         path = "/api/tv/channels"
         return self._r.get(path)
 
-    def stream_current_game(self) -> Iterator[Dict[str, Any]]:
+    def stream_current_game(self) -> Iterator[TVFeed]:
         """Streams the current TV game.
 
         :return: positions and moves of the current TV game
         """
         path = "/api/tv/feed"
-        yield from self._r.get(path, stream=True)
+        for response in self._r.get(path, stream=True):
+            yield cast(TVFeed, response)
 
-    def stream_current_game_of_channel(self, channel: str) -> Iterator[Dict[str, Any]]:
+    def stream_current_game_of_channel(self, channel: str) -> Iterator[TVFeed]:
         """Streams the current TV game of a channel.
 
         :param channel: the TV channel to stream.
         :return: positions and moves of the channels current TV game
         """
         path = f"/api/tv/{channel}/feed"
-        yield from self._r.get(path, stream=True)
+        for response in self._r.get(path, stream=True):
+            yield cast(TVFeed, response)
 
     def get_best_ongoing(
         self,

--- a/berserk/types/__init__.py
+++ b/berserk/types/__init__.py
@@ -14,6 +14,7 @@ from .opening_explorer import (
 from .studies import ChapterIdName
 from .team import PaginatedTeams, Team
 from .tournaments import ArenaResult, CurrentTournaments, SwissResult, SwissInfo
+from .tv import TVFeed
 
 __all__ = [
     "AccountInformation",
@@ -41,4 +42,5 @@ __all__ = [
     "SwissResult",
     "Team",
     "Variant",
+    "TVFeed",
 ]

--- a/berserk/types/common.py
+++ b/berserk/types/common.py
@@ -64,6 +64,8 @@ class LightUser(TypedDict):
     name: str
     # The title of the user
     title: NotRequired[Title]
+    # The flair of the user
+    flair: NotRequired[str]
     # The patron of the user
     patron: NotRequired[bool]
 

--- a/berserk/types/tv.py
+++ b/berserk/types/tv.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import List, Literal
+from typing_extensions import TypedDict, NotRequired
+
+from .common import LightUser, Color
+
+
+class Player(TypedDict):
+    color: Color
+    user: NotRequired[LightUser]
+    ai: NotRequired[int]
+    rating: NotRequired[int]
+    seconds: int
+
+
+class FeaturedData(TypedDict):
+    id: str
+    orientation: Color
+    players: List[Player]
+    fen: str
+
+
+class MoveData(TypedDict):
+    fen: str
+    lm: str
+    wc: int
+    bc: int
+
+
+class TVFeed(TypedDict):
+    t: Literal["featured", "fen"]
+    d: FeaturedData | MoveData


### PR DESCRIPTION
Implements the [/tv/{channel}/feed](https://lichess.org/api#tag/TV/operation/tvChannelFeed) endpoint and adds TypeDicts.

**NOTE:**
I attempted to add a test for this ([test_tv.py](https://gist.github.com/trevorbayless/1e25b3dcc4b86739880231f6142f2eaa)) but for some reason vcrpy hangs during `make test_record` when hitting the test (possibly because this is a stream endpoint?). In the linked test, I clipped the stream at the first two results as this endpoint is an infinite stream.

Interestingly enough, if you remove `@pytest.mark.vcr` the test passes, but we want this as a cassette. I was able to manually create a cassette for this ([TestTV.test_stream_bullet_tv.yaml](https://gist.github.com/trevorbayless/4c5714537b4e8be739c3d93bd99c1b3a)) which works, but would be problematic if the cassette needs to be regenerated so I assume this isn't something we want to manually add. vcrpy is new to me, so if anyone has an idea on what the issue might be please let me know and I'll gladly add a test for this.


<details>
<summary>Checklist when adding a new endpoint</summary>


<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] Added new endpoint to the `README.md`
- [x] Ensure that my endpoint name does not repeat the name of the client. Wrong: `client.users.get_user()`, Correct: `client.users.get()`
- [x] Typed the returned JSON using TypedDicts in `berserk/types/`, [example](https://github.com/lichess-org/berserk/blob/master/berserk/types/team.py#L32)
- [ ] Tested GET endpoints not requiring authentification. [Documentation](https://github.com/lichess-org/berserk/blob/master/CONTRIBUTING.rst#using-pytest-recording--vcrpy), [example](https://github.com/lichess-org/berserk/blob/master/tests/clients/test_teams.py#L11)
- [x] Added the endpoint and your name to `CHANGELOG.md` in the `To be released` section (to be created if necessary)
</details>