### PR TITLE
Add external engine analysis post endpoints

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,8 +8,9 @@ To be released
 * Added ``sheet`` optional parameter to ``Tournaments.stream_results``, and fix returned typed dict.
 * Added ``studies.import_pgn`` to import PGN to study
 * Added ``tv.stream_current_game_of_channel`` to stream the current TV game of a channel
+* Added ``client.external_engine.analyse``, ``client.external_engine.acquire_request``, ``client.external_engine.answer_request`` to handle analysis with an external engine
 
-Thanks to @nicvagn, @tors42, @fitztrev and @trevorbayless for their contributions to this release.
+Thanks to @nicvagn, @tors42, @fitztrev, @friedrichtenhagen and @trevorbayless for their contributions to this release.
 
 v0.13.2 (2023-12-04)
 --------------------

--- a/README.rst
+++ b/README.rst
@@ -137,6 +137,9 @@ Most of the API is available:
     client.external_engine.create
     client.external_engine.update
     client.external_engine.delete
+    client.external_engine.analyse
+    client.external_engine.acquire_request
+    client.external_engine.answer_request
 
     client.games.export
     client.games.export_ongoing_by_player

--- a/berserk/clients/external_engine.py
+++ b/berserk/clients/external_engine.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
-from typing import List, cast
+from typing import List, cast, Literal, Iterator
 
 from .base import BaseClient
+
+from ..formats import NDJSON, TEXT
+from ..types.external_engine import ExternalEngineRequest, EngineAnalysisOutput
 
 
 class ExternalEngine(BaseClient):
@@ -112,3 +115,98 @@ class ExternalEngine(BaseClient):
         """
         path = f"/api/external-engine/{engine_id}"
         self._r.request("DELETE", path)
+
+    def analyse(
+        self,
+        engine_id: str,
+        client_secret: str,
+        session_id: str,
+        threads: int,
+        hash_table_size: int,
+        pri_num_variations: int,
+        variant: Literal[
+            "chess",
+            "crazyhouse",
+            "antichess",
+            "atomic",
+            "horde",
+            "kingofthehill",
+            "racingkings",
+            "3check",
+        ],
+        initial_fen: str,
+        moves: List[str],
+        movetime: int | None = None,
+        depth: int | None = None,
+        nodes: int | None = None,
+    ) -> Iterator[EngineAnalysisOutput]:
+        """
+        Analyse with external engine
+
+        Request analysis from an external engine. Response content is streamed as newline delimited JSON.
+        The properties are based on the UCI specification.
+        Analysis stops when the client goes away, the requested limit is reached, or the provider goes away.
+
+        :param engine_id: external engine id
+        :param client_secret: engine credentials
+        :param session_id: Arbitary string that identifies the analysis session. Providers may wish to clear the hash table between sessions.
+        :param threads: Number of threads to use for analysis.
+        :param hash_table_size: Hash table size to use for analysis, in MiB.
+        :param pri_num_variations: Requested number of principal variations. (1-5)
+        :param variant: uci variant
+        :param initial_fen: Initial position of the game.
+        :param moves: List of moves played from the initial position, in UCI notation.
+        :param movetime: Amount of time to analyse the position, in milliseconds.
+        :param depth: Analysis target depth
+        :param nodes: Number of nodes to analyse in the position
+        """
+        path = f"/api/external-engine/{engine_id}/analyse"
+        custom_base_url = "https://engine.lichess.ovh"
+        payload = {
+            "clientSecret": client_secret,
+            "work": {
+                "sessionId": session_id,
+                "threads": threads,
+                "hash": hash_table_size,
+                "multiPv": pri_num_variations,
+                "variant": variant,
+                "initialFen": initial_fen,
+                "moves": moves,
+                "movetime": movetime,
+                "depth": depth,
+                "nodes": nodes,
+            },
+        }
+
+        for response in self._r.post(
+            path=path,
+            payload=payload,
+            stream=True,
+            fmt=NDJSON,
+            custom_base_url=custom_base_url,
+        ):
+            yield cast(EngineAnalysisOutput, response)
+
+    def acquire_request(self, provider_secret: str) -> ExternalEngineRequest:
+        """Wait for an analysis request to any of the external engines that have been registered with the given secret.
+        :param provider_secret: provider credentials
+        :return: the requested analysis
+        """
+        path = "/api/external-engine/work"
+        custom_base_url = "https://engine.lichess.ovh"
+        payload = {"providerSecret": provider_secret}
+        return cast(
+            ExternalEngineRequest,
+            self._r.post(path=path, payload=payload, custom_base_url=custom_base_url),
+        )
+
+    def answer_request(self, engine_id: str) -> str:
+        """Submit a stream of analysis as UCI output.
+        The server may close the connection at any time, indicating that the requester has gone away and analysis
+        should be stopped.
+        :param engine_id: engine ID
+        :return: the requested analysis
+        """
+        path = f"/api/external-engine/work/{engine_id}"
+        custom_base_url = "https://engine.lichess.ovh"
+        return self._r.post(path=path, fmt=TEXT, custom_base_url=custom_base_url)

--- a/berserk/session.py
+++ b/berserk/session.py
@@ -56,6 +56,7 @@ class Requestor(Generic[T]):
         json: Dict[str, Any] | None = None,
         fmt: FormatHandler[Any] | None = None,
         converter: Converter[Any] = utils.noop,
+        custom_base_url: str | None = None,
         **kwargs: Any,
     ) -> Any | Iterator[Any]:
         """Make a request for a resource in a paticular format.
@@ -68,11 +69,17 @@ class Requestor(Generic[T]):
         :param json: request body json
         :param fmt: the format handler
         :param converter: function to handle field conversions
+        :param custom_base_url: change the base url
         :return: response
         :raises berserk.exceptions.ResponseError: if the status is >=400
         """
         fmt = fmt or self.default_fmt
-        url = urljoin(self.base_url, path)
+
+        if custom_base_url:
+            base_url = custom_base_url
+        else:
+            base_url = self.base_url
+        url = urljoin(base_url, path)
 
         LOG.debug(
             "%s %s %s params=%s data=%s json=%s",
@@ -197,6 +204,7 @@ class Requestor(Generic[T]):
         json: Dict[str, Any] | None = None,
         fmt: FormatHandler[U],
         converter: Converter[U] = utils.noop,
+        custom_base_url: str | None = None,
         **kwargs: Any,
     ) -> U:
         ...
@@ -212,6 +220,7 @@ class Requestor(Generic[T]):
         json: Dict[str, Any] | None = None,
         fmt: FormatHandler[U],
         converter: Converter[U] = utils.noop,
+        custom_base_url: str | None = None,
         **kwargs: Any,
     ) -> Iterator[U]:
         ...
@@ -227,6 +236,7 @@ class Requestor(Generic[T]):
         json: Dict[str, Any] | None = None,
         fmt: None = None,
         converter: Converter[T] = utils.noop,
+        custom_base_url: str | None = None,
         **kwargs: Any,
     ) -> T:
         ...
@@ -242,6 +252,7 @@ class Requestor(Generic[T]):
         json: Dict[str, Any] | None = None,
         fmt: None = None,
         converter: Converter[T] = utils.noop,
+        custom_base_url: str | None = None,
         **kwargs: Any,
     ) -> Iterator[T]:
         ...
@@ -256,6 +267,7 @@ class Requestor(Generic[T]):
         json: Dict[str, Any] | None = None,
         fmt: FormatHandler[Any] | None = None,
         converter: Any = utils.noop,
+        custom_base_url: str | None = None,
         **kwargs: Any,
     ) -> Any | Iterator[Any]:
         """Convenience method to make a POST request."""
@@ -268,6 +280,7 @@ class Requestor(Generic[T]):
             converter=converter,
             data=data,
             json=json,
+            custom_base_url=custom_base_url,
             **kwargs,
         )
 

--- a/berserk/types/common.py
+++ b/berserk/types/common.py
@@ -12,27 +12,6 @@ class ClockConfig(TypedDict):
     increment: int
 
 
-class ExternalEngine(TypedDict):
-    # Engine ID
-    id: str
-    # Engine display name
-    name: str
-    # Secret token that can be used to request analysis
-    clientSecret: str
-    # User this engine has been registered for
-    userId: str
-    # Max number of available threads
-    maxThreads: int
-    # Max available hash table size, in MiB
-    maxHash: int
-    # Estimated depth of normal search
-    defaultDepth: int
-    # List of supported chess variants
-    variants: str
-    # Arbitrary data that engine provider can use for identification or bookkeeping
-    providerData: NotRequired[str]
-
-
 Color: TypeAlias = Literal["white", "black"]
 
 GameType: TypeAlias = Literal[

--- a/berserk/types/external_engine.py
+++ b/berserk/types/external_engine.py
@@ -1,0 +1,71 @@
+from typing import List
+
+from typing_extensions import TypedDict, NotRequired
+
+
+class ExternalEngine(TypedDict):
+    # Engine ID
+    id: str
+    # Engine display name
+    name: str
+    # Secret token that can be used to request analysis
+    clientSecret: str
+    # User this engine has been registered for
+    userId: str
+    # Max number of available threads
+    maxThreads: int
+    # Max available hash table size, in MiB
+    maxHash: int
+    # Estimated depth of normal search
+    defaultDepth: int
+    # List of supported chess variants
+    variants: str
+    # Arbitrary data that engine provider can use for identification or bookkeeping
+    providerData: NotRequired[str]
+
+
+class ExternalEngineWork(TypedDict):
+    # Arbitrary string that identifies the analysis session. Providers may clear the hash table between sessions
+    sessionId: str
+    # Number of threads to use for analysis
+    threads: int
+    # Hash table size to use for analysis, in MiB
+    hash: int
+    # Requested number of principle variations
+    multiPv: List[int]
+    # Uci variant
+    variant: str
+    # Initial position of the game
+    initialFen: str
+    # List of moves played from the initial position, in UCI notation
+    moves: List[str]
+    # Request an infinite search (rather than roughly aiming for defaultDepth)
+    infinite: NotRequired[bool]
+
+
+class ExternalEngineRequest(TypedDict):
+    id: str
+    work: ExternalEngineWork
+    engine: ExternalEngine
+
+
+class PrincipleVariationAnalysis(TypedDict):
+    # Current search depth of the pv
+    depth: int
+    # Variation in UCI notation
+    moves: List[str]
+    # Evaluation in centi-pawns, from White's point of view
+    cp: NotRequired[int]
+    # Evaluation in signed moves to mate, from White's point of view
+    mate: NotRequired[int]
+
+
+class EngineAnalysisOutput(TypedDict):
+    # Number of milliseconds the search has been going on
+    time: int
+    # Current search depth
+    depth: int
+    # Number of nodes visited so far
+    nodes: int
+    # Information about up to 5 pvs, with the primary pv at index 0
+    pvs: List[PrincipleVariationAnalysis]


### PR DESCRIPTION
<!-- Describe your pull request here.-->


<details>
<summary>Checklist when adding a new endpoint</summary>
Building on @Anupyas PR I moved the analysis endpoints into the external_engine client. I handled the different base URL with a new parameter in the Requestor methods post and request which accepts the different base url.

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] Added new endpoint to the `README.md`
- [x] Ensure that my endpoint name does not repeat the name of the client. Wrong: `client.users.get_user()`, Correct: `client.users.get()`
- [x] Typed the returned JSON using TypedDicts in `berserk/types/`, [example](https://github.com/lichess-org/berserk/blob/master/berserk/types/team.py#L32)
- [ ] Tested GET endpoints not requiring authentification. [Documentation](https://github.com/lichess-org/berserk/blob/master/CONTRIBUTING.rst#using-pytest-recording--vcrpy), [example](https://github.com/lichess-org/berserk/blob/master/tests/clients/test_teams.py#L11)
- [x] Added the endpoint and your name to `CHANGELOG.md` in the `To be released` section (to be created if necessary)
</details>