### PR TITLE
Update test container

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-    container: ubuntu-24.04
+    container: ubuntu:latest
     services:
       bdit_lila:
         image: ghcr.io/lichess-org/lila-docker:main

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -6,11 +6,11 @@ on:
 
 jobs:
   lila:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-    container: ubuntu:22.04
+    container: ubuntu-24.04
     services:
       bdit_lila:
         image: ghcr.io/lichess-org/lila-docker:main


### PR DESCRIPTION
Fixes github action during dependency setup

```
$ python -m pip install --upgrade pip
python: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.38' not found
```