### PR TITLE
Implement get_next_puzzle endpoint

### DIFF
--- a/berserk/clients/puzzles.py
+++ b/berserk/clients/puzzles.py
@@ -5,7 +5,7 @@ from typing import Iterator, Any, Dict, cast
 from .. import models
 from ..formats import NDJSON
 from .base import BaseClient
-from ..types import PuzzleRace
+from ..types import PuzzleRace, NextPuzzle
 
 
 class Puzzles(BaseClient):
@@ -78,3 +78,25 @@ class Puzzles(BaseClient):
         """
         path = "/api/racer"
         return cast(PuzzleRace, self._r.post(path))
+
+    def get_next_puzzle(self, rating: int | None = None) -> NextPuzzle:
+        """Get the next puzzle for the authenticated user.
+
+        The user's puzzle rating and history influence the puzzle choice.
+        Optionally, a puzzle rating can be specified, overriding the user's rating.
+
+        Requires authentication (OAuth scope: `puzzle:read`).
+
+        https://lichess.org/api#tag/Puzzles/operation/apiPuzzleNext
+
+        :param rating: Optional puzzle rating to target. If omitted, the user's
+                       current puzzle rating is used.
+        :return: A dictionary containing the puzzle details and the source game.
+        """
+        path = "/api/puzzle/next"
+        params = {"rating": rating} if rating is not None else {}
+        # Note: Authentication is handled by the underlying session/requester
+        # when the berserk.Client is initialized with a token.
+        # The Lichess API uses POST for this endpoint.
+        response = self._r.post(path, params=params)
+        return cast(NextPuzzle, response)

--- a/berserk/types/__init__.py
+++ b/berserk/types/__init__.py
@@ -5,7 +5,7 @@ from .broadcast import BroadcastPlayer
 from .bulk_pairings import BulkPairing, BulkPairingGame
 from .challenges import Challenge
 from .common import ClockConfig, ExternalEngine, LightUser, OnlineLightUser, Variant
-from .puzzles import PuzzleRace
+from .puzzles import PuzzleRace, NextPuzzle
 from .opening_explorer import (
     OpeningExplorerRating,
     OpeningStatistic,
@@ -36,6 +36,7 @@ __all__ = [
     "Preferences",
     "Profile",
     "PuzzleRace",
+    "NextPuzzle",
     "Speed",
     "StreamerInfo",
     "SwissInfo",

--- a/berserk/types/puzzles.py
+++ b/berserk/types/puzzles.py
@@ -1,6 +1,39 @@
 from __future__ import annotations
 
-from typing_extensions import TypedDict
+from typing_extensions import TypedDict, List
+
+from .common import LightUser, ClockConfig
+
+
+class PuzzleInfo(TypedDict):
+    """Structure containing information about a specific puzzle."""
+
+    id: str
+    rating: int
+    plays: int
+    solution: List[str]
+    themes: List[str]
+    initialFen: str
+    initialPly: int
+    gameId: str
+
+
+class PuzzleGame(TypedDict):
+    """Structure containing information about the game the puzzle originated from."""
+
+    id: str
+    clock: ClockConfig
+    perf: str
+    pgn: str
+    players: List[LightUser]
+    rated: bool
+
+
+class NextPuzzle(TypedDict):
+    """Structure representing the response for the next puzzle request."""
+
+    puzzle: PuzzleInfo
+    game: PuzzleGame
 
 
 class PuzzleRace(TypedDict):


### PR DESCRIPTION
<!-- Describe your pull request here.-->
This PR implements the `/api/puzzle/next` endpoint within the `Puzzles` client as the `get_next_puzzle` method.

This method allows fetching the next puzzle suggested for the authenticated user, based on their puzzle rating and history. It also allows optionally specifying a target `rating` for the puzzle to be fetched.

Key changes:
- Added the `get_next_puzzle(rating: int | None = None)` method to the `berserk.clients.Puzzles` class.
- This endpoint requires authentication (OAuth scope: `puzzle:read`) and uses the POST HTTP method as specified by the Lichess API.
- Added new `TypedDict` definitions (`NextPuzzle`, `PuzzleInfo`, `PuzzleGame`) in a new file `berserk/types/puzzles.py` to strongly type the JSON response.
- Updated `berserk/types/__init__.py` to export the new `NextPuzzle` type.
- Formatted the docstring according to the project's style.


<details>
<summary>Checklist when adding a new endpoint</summary>


<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] Added new endpoint to the `README.md`
- [x] Ensured that my endpoint name does not repeat the name of the client. Wrong: `client.users.get_user()`, Correct: `client.users.get()`
- [x] Typed the returned JSON using TypedDicts in `berserk/types/`, [example](https://github.com/lichess-org/berserk/blob/master/berserk/types/team.py#L32)
- [ ] Written tests for GET endpoints not requiring authentification. [Documentation](https://github.com/lichess-org/berserk/blob/master/CONTRIBUTING.rst#using-pytest-recording--vcrpy), [example](https://github.com/lichess-org/berserk/blob/master/tests/clients/test_teams.py#L11) *(Note: This endpoint requires auth and uses POST, so tests will need specific handling, e.g., VCR with token)*
- [ ] Added the endpoint and your name to `CHANGELOG.md` in the `To be released` section (to be created if necessary)
</details>