### PR TITLE
Add broadcasts.get_by_user endpoint to get broadcasts created by a user

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ To be released
 * Added ``pgn_in_json`` parameter to ``client.games.export``.
 * Implement `broadcasts.get_top()` endpoint; typing fixes and validation.
 * Added ``client.broadcasts.search`` to search for broadcasts.
+* Added ``client.broadcasts.get_by_user`` to get broadcasts created by a user.
 * Added ``client.relations.block`` and ``client.relations.unblock`` for blocking/unblocking users.
 * Implemented ``/api/games/export/imports`` under
   ``client.games.export_imported``.

--- a/README.rst
+++ b/README.rst
@@ -115,6 +115,7 @@ Most of the API is available:
     client.broadcasts.stream_round
     client.broadcasts.get_top
     client.broadcasts.search
+    client.broadcasts.get_by_user
 
     client.bulk_pairings.get_upcoming
     client.bulk_pairings.create

--- a/berserk/clients/broadcasts.py
+++ b/berserk/clients/broadcasts.py
@@ -6,7 +6,12 @@ from .. import models
 from ..formats import PGN
 from .base import BaseClient
 
-from ..types.broadcast import BroadcastPlayer, BroadcastTop, PaginatedBroadcasts
+from ..types.broadcast import (
+    BroadcastPlayer,
+    BroadcastTop,
+    PaginatedBroadcasts,
+    BroadcastsByUser,
+)
 from ..utils import to_str
 
 
@@ -274,3 +279,20 @@ class Broadcasts(BaseClient):
         path = "/api/broadcast/search"
         params = {"q": query, "page": page}
         return cast(PaginatedBroadcasts, self._r.get(path, params=params))
+
+    def get_by_user(
+        self,
+        username: str,
+        page: int = 1,
+        html: bool = False,
+    ) -> BroadcastsByUser:
+        """Get broadcasts created by a user.
+
+        :param username: the username
+        :param page: the page number to fetch (default: 1)
+        :param html: convert description from markdown to HTML (default: False)
+        :return: paginated list of broadcasts created by the user
+        """
+        path = f"/api/broadcast/by/{username}"
+        params = {"page": page, "html": html}
+        return cast(BroadcastsByUser, self._r.get(path, params=params))

--- a/berserk/types/__init__.py
+++ b/berserk/types/__init__.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
 from .account import AccountInformation, Perf, Preferences, Profile, StreamerInfo
-from .broadcast import BroadcastPlayer, BroadcastTop, PaginatedBroadcasts
+from .broadcast import (
+    BroadcastPlayer,
+    BroadcastTop,
+    PaginatedBroadcasts,
+    BroadcastsByUser,
+)
 from .bulk_pairings import BulkPairing, BulkPairingGame
 from .challenges import ChallengeJson
 from .common import ClockConfig, ExternalEngine, LightUser, OnlineLightUser, VariantKey
@@ -21,6 +26,7 @@ __all__ = [
     "AccountInformation",
     "ArenaResult",
     "BroadcastPlayer",
+    "BroadcastsByUser",
     "BroadcastTop",
     "BulkPairing",
     "BulkPairingGame",

--- a/berserk/types/broadcast.py
+++ b/berserk/types/broadcast.py
@@ -90,3 +90,17 @@ class BroadcastTop(TypedDict):
     active: List[BroadcastWithLastRound]
     upcoming: List[None]  # deprecated
     past: PaginatedBroadcasts
+
+
+class BroadcastByUser(TypedDict):
+    tour: BroadcastTour
+
+
+class BroadcastsByUser(TypedDict):
+    currentPage: int
+    maxPerPage: int
+    currentPageResults: List[BroadcastByUser]
+    nbResults: int
+    previousPage: int | None
+    nextPage: int | None
+    nbPages: int

--- a/tests/clients/cassettes/test_broadcasts/TestBroadcasts.test_get_by_user.yaml
+++ b/tests/clients/cassettes/test_broadcasts/TestBroadcasts.test_get_by_user.yaml
@@ -1,0 +1,58 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.5
+    method: GET
+    uri: https://lichess.org/api/broadcast/by/lichess?page=1&html=False
+  response:
+    body:
+      string: '{"currentPage":1,"maxPerPage":24,"currentPageResults":[{"tour":{"id":"k4TVpyO7","name":"FIDE
+        World Corporate Chess Championship 2025 | Online Qualifier 4","slug":"fide-world-corporate-chess-championship-2025--online-qualifier-4","info":{"format":"7-round
+        Team Swiss","tc":"10+3","fideTc":"standard","location":"lichess.org","timeZone":"Etc/UTC","standings":"https://fwccc.lichess.ca/fwccc-qualifier4/season/2025/standings/"},"createdAt":1760282145291,"url":"https://lichess.org/broadcast/fide-world-corporate-chess-championship-2025--online-qualifier-4/k4TVpyO7","tier":5,"dates":[1760291984000],"image":"https://image.lichess1.org/display?fmt=webp&h=400&op=thumbnail&path=relay:k4TVpyO7:8YEFzYA4.webp&w=800&sig=1c57f41fca334b724c2a9c6906be795ec7ff93da","teamTable":true}},{"tour":{"id":"8ksEjJjX","name":"FIDE
+        World Corporate Chess Championship 2025 | Online Qualifier 2","slug":"fide-world-corporate-chess-championship-2025--online-qualifier-2","info":{"format":"7-round
+        Team Swiss","tc":"10+3","fideTc":"standard","location":"lichess.org","timeZone":"Etc/UTC","players":"RaviKhanna08
+        Metsfan2000 claudioa shivamsingh1607","standings":"https://fwccc.lichess.ca/fwccc-qualifier2/season/2025/standings/"},"createdAt":1760196441335,"url":"https://lichess.org/broadcast/fide-world-corporate-chess-championship-2025--online-qualifier-2/8ksEjJjX","tier":5,"dates":[1760198358000],"image":"https://image.lichess1.org/display?fmt=webp&h=400&op=thumbnail&path=relay:8ksEjJjX:MDRZRJNC.webp&w=800&sig=4d7f2c91bb32faca4c7a3d3fa3eb6dcb6711cfae","teamTable":true}},{"tour":{"id":"oNCIoKlO","name":"FIDE
+        World Corporate Chess Championship 2025 | Online Qualifier 1","slug":"fide-world-corporate-chess-championship-2025--online-qualifier-1","info":{"format":"7-round
+        Team Swiss","tc":"10+3","fideTc":"standard","location":"lichess.org","timeZone":"Etc/UTC","players":"ItRelates,
+        malyy, rightitsrafa, watchmecheck"},"createdAt":1760130207621,"url":"https://lichess.org/broadcast/fide-world-corporate-chess-championship-2025--online-qualifier-1/oNCIoKlO","tier":5,"dates":[1760173842000],"image":"https://image.lichess1.org/display?fmt=webp&h=400&op=thumbnail&path=relay:oNCIoKlO:XrEncJ7k.webp&w=800&sig=6939c7b73ad032332c970723eff5dde1e01eec5c","teamTable":true}},{"tour":{"id":"jACOzu7b","name":"Solidarity
+        Friendly Match Sweden-Ukraine","slug":"solidarity-friendly-match-sweden-ukraine","info":{"format":"Team
+        Match","tc":"Rapid"},"createdAt":1648051116225,"url":"https://lichess.org/broadcast/solidarity-friendly-match-sweden-ukraine/jACOzu7b","tier":3,"dates":[1648054800000,1648058400000]}}],"previousPage":null,"nextPage":null,"nbResults":4,"nbPages":1}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Authorization, If-Modified-Since, Cache-Control, Content-Type
+      Access-Control-Allow-Methods:
+      - OPTIONS, GET, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 26 Nov 2025 03:09:06 GMT
+      Permissions-Policy:
+      - interest-cohort=()
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      X-Frame-Options:
+      - DENY
+      content-length:
+      - '2644'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/clients/test_broadcasts.py
+++ b/tests/clients/test_broadcasts.py
@@ -1,7 +1,7 @@
 import pytest
 
 from berserk import Client
-from berserk.types import BroadcastTop, PaginatedBroadcasts
+from berserk.types import BroadcastTop, PaginatedBroadcasts, BroadcastsByUser
 from utils import skip_if_older_3_dot_10, validate
 
 
@@ -17,3 +17,9 @@ class TestBroadcasts:
     def test_search(self):
         res = Client().broadcasts.search(query="chess", page=1)
         validate(PaginatedBroadcasts, res)
+
+    @skip_if_older_3_dot_10
+    @pytest.mark.vcr
+    def test_get_by_user(self):
+        res = Client().broadcasts.get_by_user(username="lichess", page=1)
+        validate(BroadcastsByUser, res)


### PR DESCRIPTION
<!-- Describe your pull request here.-->

This PR is a small part of https://github.com/lichess-org/berserk/issues/6 and implements broadcasts.get_by_user() endpoint to retrieve broadcasts created by a specific user

Summary:


- Implement client.broadcasts.get_by_user() to fetch paginated broadcasts by username
- Add BroadcastsByUser TypedDict for response typing
- Add test with VCR cassette validation

<details>
<summary>Checklist when adding a new endpoint</summary>


<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] Added new endpoint to the `README.md`
- [x] Ensured that my endpoint name does not repeat the name of the client. Wrong: `client.users.get_user()`, Correct: `client.users.get()`
- [x] Typed the returned JSON using TypedDicts in `berserk/types/`, [example](https://github.com/lichess-org/berserk/blob/master/berserk/types/team.py#L32)
- [x] Written tests for GET endpoints not requiring authentification. [Documentation](https://github.com/lichess-org/berserk/blob/master/CONTRIBUTING.rst#using-pytest-recording--vcrpy), [example](https://github.com/lichess-org/berserk/blob/master/tests/clients/test_teams.py#L11)
- [x] Added the endpoint and your name to `CHANGELOG.md` in the `To be released` section (to be created if necessary)
</details>
