### PR TITLE
Add endpoint /api/board/game/.../claim-draw (#6)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,7 @@ To be released
   of a given user.
 * Added ``bots.handle_draw_offer`` and ``bots.handle_takeback_offer`` to handle draw and takeback offers
 * Added ``client.external_engine.analyse``, ``client.external_engine.acquire_request``, ``client.external_engine.answer_request`` to handle analysis with an external engine
+* Added ``client.board.claim_draw`` to claim draw after the opponent has left the game
 
 
 Thanks to all the contributors who helped to this release:

--- a/README.rst
+++ b/README.rst
@@ -91,6 +91,7 @@ Most of the API is available:
     client.board.accept_takeback
     client.board.decline_takeback
     client.board.claim_victory
+    client.board.claim_draw
     client.board.go_berserk
 
     client.bots.get_online_bots

--- a/berserk/clients/board.py
+++ b/berserk/clients/board.py
@@ -209,6 +209,18 @@ class Board(BaseClient):
         path = f"/api/board/game/{game_id}/claim-victory/"
         self._r.post(path)
 
+    def claim_draw(self, game_id: str) -> None:
+        """Claim draw when the opponent has left the game for a while.
+
+        Generally, this should only be called once the `opponentGone` event
+        is received in the board game state stream and the `claimWinInSeconds`
+        time has elapsed.
+
+        :param str game_id: ID of an in-progress game
+        """
+        path = f"/api/board/game/{game_id}/claim-draw/"
+        self._r.post(path)
+
     def go_berserk(self, game_id: str) -> None:
         """Go berserk on an arena tournament game.
 


### PR DESCRIPTION
Hello,
I just added the ``client.board.claim_draw`` method for the missing ``/api/board/game/.../claim-draw`` endpoint (part of #6 )
It's pretty much the same as claim_victory right next to it.