### PR TITLE
Implement missing endpoints for bots to claim victory or draw (#6)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,7 +22,7 @@ To be released
   of a given user.
 * Added ``bots.handle_draw_offer`` and ``bots.handle_takeback_offer`` to handle draw and takeback offers
 * Added ``client.external_engine.analyse``, ``client.external_engine.acquire_request``, ``client.external_engine.answer_request`` to handle analysis with an external engine
-
+* Added ``bots.claim_draw`` and ``bots.claim_victory``, allowing bots to end the game if the opponent has left or disconnected.
 
 Thanks to all the contributors who helped to this release:
 - @hsheth2
@@ -31,6 +31,7 @@ Thanks to all the contributors who helped to this release:
 - @gameroman
 - @JAMoreno-Larios
 - @friedrichtenhagen
+- @nleonh
 
 
 v0.14.0 (2025-08-26)

--- a/README.rst
+++ b/README.rst
@@ -104,6 +104,8 @@ Most of the API is available:
     client.bots.handle_takeback_offer
     client.bots.accept_challenge
     client.bots.decline_challenge
+    client.bots.claim_draw
+    client.bots.claim_victory
 
     client.broadcasts.get_official
     client.broadcasts.create

--- a/berserk/clients/bots.py
+++ b/berserk/clients/bots.py
@@ -98,7 +98,7 @@ class Bots(BaseClient):
 
     def claim_victory(self, game_id: str) -> None:
         """Claim victory in a bot game after the opponent left the game
-        
+
         :param game_id: ID of a game
         """
         path = f"/api/bot/game/{game_id}/claim-victory"

--- a/berserk/clients/bots.py
+++ b/berserk/clients/bots.py
@@ -88,6 +88,22 @@ class Bots(BaseClient):
         path = f"/api/bot/game/{game_id}/draw/{int(accept)}"
         self._r.post(path)
 
+    def claim_draw(self, game_id: str) -> None:
+        """Claim draw in a bot game after the opponent left the game
+
+        :param game_id ID of a game
+        """
+        path = f"/api/bot/game/{game_id}/claim-draw"
+        self._r.post(path)
+
+    def claim_victory(self, game_id: str) -> None:
+        """Claim victory in a bot game after the opponent left the game
+        
+        :param game_id: ID of a game
+        """
+        path = f"/api/bot/game/{game_id}/claim-victory"
+        self._r.post(path)
+
     def handle_takeback_offer(self, game_id: str, accept: bool) -> None:
         """Create/accept/decline takeback offers
 


### PR DESCRIPTION
Hi,
I added these two missing endpoints (#6):
- ```/api/bot/game/{gameId}/claim-victory```
- ```/api/bot/game/{gameId}/claim-draw```

<details>
<summary>Checklist when adding a new endpoint</summary>


<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] Added new endpoint to the `README.md`
- [x] Ensured that my endpoint name does not repeat the name of the client. Wrong: `client.users.get_user()`, Correct: `client.users.get()`
- [ ] Typed the returned JSON using TypedDicts in `berserk/types/`, [example](https://github.com/lichess-org/berserk/blob/master/berserk/types/team.py#L32)
*doesn't need to be typed (no response data)*
- [ ] Written tests for GET endpoints not requiring authentification. [Documentation](https://github.com/lichess-org/berserk/blob/master/CONTRIBUTING.rst#using-pytest-recording--vcrpy), [example](https://github.com/lichess-org/berserk/blob/master/tests/clients/test_teams.py#L11)
*requires auth*
- [x] Added the endpoint and your name to `CHANGELOG.md` in the `To be released` section (to be created if necessary)
</details>
