### PR TITLE
Add broadcast round reset endpoint

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ To be released
 * Implement `broadcasts.get_top()` endpoint; typing fixes and validation.
 * Added ``client.broadcasts.search`` to search for broadcasts.
 * Added ``client.broadcasts.get_by_user`` to get broadcasts created by a user.
+* Added ``client.broadcasts.reset_round`` to reset a broadcast round to its initial state.
 * Added ``client.relations.block`` and ``client.relations.unblock`` for blocking/unblocking users.
 * Implemented ``/api/games/export/imports`` under
   ``client.games.export_imported``.
@@ -31,6 +32,7 @@ Thanks to all the contributors who helped to this release:
 - @gameroman
 - @JAMoreno-Larios
 - @friedrichtenhagen
+- @philyawj
 
 
 v0.14.0 (2025-08-26)

--- a/README.rst
+++ b/README.rst
@@ -113,6 +113,7 @@ Most of the API is available:
     client.broadcasts.create_round
     client.broadcasts.get_round
     client.broadcasts.update_round
+    client.broadcasts.reset_round
     client.broadcasts.get_round_pgns
     client.broadcasts.get_pgns
     client.broadcasts.stream_round

--- a/berserk/clients/broadcasts.py
+++ b/berserk/clients/broadcasts.py
@@ -203,6 +203,14 @@ class Broadcasts(BaseClient):
         }
         return self._r.post(path, json=payload, converter=models.Broadcast.convert)
 
+    def reset_round(self, broadcast_round_id: str) -> None:
+        """Remove all games from a broadcast round and reset it to its initial state.
+
+        :param broadcast_round_id: broadcast round ID
+        """
+        path = f"/api/broadcast/round/{broadcast_round_id}/reset"
+        self._r.post(path)
+
     def get_round_pgns(self, broadcast_round_id: str) -> Iterator[str]:
         """Get all games of a single round of a broadcast in PGN format.
 

--- a/tests/clients/test_broadcasts.py
+++ b/tests/clients/test_broadcasts.py
@@ -1,4 +1,5 @@
 import pytest
+import requests_mock
 
 from berserk import Client
 from berserk.types import BroadcastTop, PaginatedBroadcasts, BroadcastsByUser
@@ -6,6 +7,17 @@ from utils import skip_if_older_3_dot_10, validate
 
 
 class TestBroadcasts:
+    def test_reset_round(self):
+        with requests_mock.Mocker() as mock:
+            mock.post(
+                "https://lichess.org/api/broadcast/round/abcdefgh/reset",
+                json={"ok": True},
+            )
+
+            result = Client().broadcasts.reset_round("abcdefgh")
+
+            assert result is None
+
     @skip_if_older_3_dot_10
     @pytest.mark.vcr
     def test_get_top(self):


### PR DESCRIPTION
## Summary

- add `client.broadcasts.reset_round(broadcast_round_id)`
- POST to `/api/broadcast/round/{broadcastRoundId}/reset`
- document the endpoint and add changelog credit
- test the exact HTTP method and path with `requests-mock`

Part of #6.

## Testing

- `uv run pytest tests/clients/test_broadcasts.py -q` (4 passed)
- `uv run pytest tests -q` (52 passed)
- `uv run pyright berserk integration/local.py` (0 errors)
- `uv run ruff format . --diff` (70 files already formatted)
- `uv run sphinx-build -b html docs _build -EW --keep-going` (succeeded)
- `check-endpoints.py` against the current official Lichess OpenAPI spec no longer reports the reset endpoint as missing

## Endpoint checklist

- [x] Added `client.broadcasts.reset_round` to `README.rst`
- [x] Used a non-redundant method name consistent with `create_round` and `update_round`
- [x] Typed the public return as `None`, matching existing mutation methods that intentionally discard the `{ "ok": true }` acknowledgment
- [x] Added a client-side request test for the authenticated POST endpoint
- [x] Added the endpoint and `@philyawj` to `CHANGELOG.rst`

## AI usage disclosure

OpenAI Codex was used to inspect issue #6 and the official API specification, select the smallest unclaimed endpoint, implement the method, write the test and documentation/changelog entries, run validation, and draft this PR description.

I, philyawj, have reviewed all code in this pull request and understand what it does and how it fits the existing berserk client. I also reviewed the fork draft before this upstream submission.
