### PR TITLE
Maintain Sphinx docs configuration

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,14 +4,14 @@ on:
   push:
     branches: ["master"]
     paths:
-      - ".github/workflows/deploy-docs.yml"
+      - ".github/workflows/docs.yml"
       - "**.py"
       - "**.rst"
       - "uv.lock"
       - "pyproject.toml"
   pull_request:
     paths:
-      - ".github/workflows/check-docs.yml"
+      - ".github/workflows/docs.yml"
       - "**.py"
       - "**.rst"
       - "uv.lock"
@@ -19,6 +19,9 @@ on:
 
   # Allows running this workflow manually from the Actions tab
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 concurrency:
   group: "docs-${{ github.ref }}"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,14 +39,14 @@ extensions = [
 ]
 autodoc_typehints = "both"
 
-source_suffix = ".rst"
+source_suffix = {".rst": "restructuredtext"}
 
-# The master toctree document.
-master_doc = "index"
+# The root toctree document.
+root_doc = "index"
 
 # General information about the project.
 project = "berserk"
-copyright = "2018-2023, Lichess and contributors"
+copyright = "2018-2026, Lichess and contributors"
 author = "Lichess"
 
 # version


### PR DESCRIPTION
## Summary

This is a small standalone maintenance pass over the Sphinx documentation configuration and its GitHub Pages workflow:

1. Replace the stale `deploy-docs.yml` and `check-docs.yml` path filters with the actual `docs.yml` filename, so workflow-only changes trigger the docs checks.
2. Set the workflow's default token permission to read-only repository contents; the deploy job retains its explicit Pages permissions.
3. Use Sphinx's explicit `source_suffix` mapping instead of relying on the legacy string conversion.
4. Use the modern `root_doc` setting instead of the legacy `master_doc` name.
5. Update the documentation copyright range from 2018–2023 to 2018–2026.

This is routine maintenance and is not associated with an issue.

## Testing

- `sphinx-build -b html docs /tmp/berserk-docs-maintenance -EW --keep-going` (succeeded)
- confirmed the previous `source_suffix` conversion notice is gone
- confirmed generated pages contain `Copyright 2018-2026, Lichess and contributors`
- parsed the workflow YAML and asserted both self-trigger paths and the default permission
- `pytest tests -q` (51 passed)
- `pyright berserk integration/local.py` (0 errors)
- `ruff format . --diff` (70 files already formatted)

## AI usage disclosure

OpenAI Codex was used to audit the Sphinx and GitHub Pages configuration, inspect its history, identify the five maintenance fixes, implement them, run validation, and draft this PR description.

I, philyawj, have reviewed all changes in this pull request and understand what they do and how they affect the documentation build and deployment workflow. I also reviewed the fork draft before this upstream submission.
